### PR TITLE
ENH: Measure Average

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
-pytest
 codecov
 doctr
+flake8
 ophyd
+pytest
 sphinx
 sphinx_rtd_theme
-flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 pytest
 codecov
 doctr
+ophyd
 sphinx
 sphinx_rtd_theme
 flake8

--- a/nabs/plan_stubs.py
+++ b/nabs/plan_stubs.py
@@ -1,0 +1,54 @@
+from bluesky.plans import count
+from bluesky.plan_stubs import subscribe
+from bluesky.preprocessors import stub_wrapper
+
+from nabs.streams import AverageStream
+
+
+def measure_average(detectors, num, delay=None, stream=None):
+    """
+    Measure an average over a number of shots from a set of detectors
+
+    Parameters
+    ----------
+    detectors : list
+        List of detectors to read
+
+    num : int
+        Number of shots to average together
+
+    delay: iterable or scalar, optional
+        Time delay between successive readings. See ``bluesky.count`` for more
+        details
+
+    stream : AverageStream, optional
+        If a plan will call :func:`.measure_average` multiple times, a single
+        ``AverageStream`` instance can be created and then passed in on each
+        call. This allows other callbacks to subscribe to the averaged data
+        stream. If no ``AverageStream`` is provided then one is created for the
+        purpose of this function.
+
+    Returns
+    -------
+    averaged_event : dict
+        A dictionary of all the measurements taken from the list of detectors
+        averaged for ``num`` shots. The keys follow the same naming convention
+        as that will appear in the event documents i.e "{name}_{field}"
+
+    Notes
+    -----
+    The returned average dictionary will only contain keys for 'number' or
+    'array' fields. Field types that can not be averaged such as 'string' will
+    be ignored, do not expect them in the output.
+    """
+    # Create a stream and subscribe if not given one
+    if not stream:
+        stream = AverageStream(n=num)
+        yield from subscribe('all', stream)
+    # Ensure we sync our stream with request if using a prior one
+    else:
+        stream.n = num
+    # Measure our detectors
+    yield from stub_wrapper(count(detectors, num=num, delay=delay))
+    # Return the measured average as a dictionary for use in adaptive plans
+    return stream.last_event['data']

--- a/nabs/streams.py
+++ b/nabs/streams.py
@@ -1,0 +1,77 @@
+"""Standard data streams for automated routines"""
+import streamz
+import numpy as np
+from bluesky.callbacks.stream import LiveDispatcher
+
+
+class AverageStream(LiveDispatcher):
+    """
+    Stream that averages data points together
+
+    As event documents are emitted from the RunEngine they are collected by
+    AverageStream, averaged and re-emitted as a secondary event stream. This
+    allows callbacks to subscribe to the average stream for more elegant
+    visualization and analysis.
+
+    The average stream can either be constructed with a specific number of
+    points to average or this information can be passed through in the start
+    document metadata. See the :meth:`.start` for more information.
+
+    Parameters
+    ----------
+    n : int, optional
+        Number of points to average together
+    """
+    def __init__(self, n=None):
+        self.n = n
+        self.in_node = None
+        self.out_node = None
+        self.averager = None
+        super().__init__()
+
+    def start(self, doc):
+        """
+        Create the stream after seeing the start document
+
+        The callback looks for the 'average' key in the start document to
+        configure itself.
+        """
+        # Grab the average key
+        self.n = doc.get('average', self.n)
+        # Define our nodes
+        if not self.in_node:
+            self.in_node = streamz.Source(stream_name='Input')
+
+        self.averager = self.in_node.partition(self.n)
+
+        def average_events(cache):
+            average_evt = dict()
+            desc_id = cache[0]['descriptor']
+            # Check that all of our events came from the same configuration
+            if not all([desc_id == evt['descriptor'] for evt in cache]):
+                raise Exception('The events in this bundle are from '
+                                'different configurations!')
+            # Use the last descriptor to avoid strings and objects
+            data_keys = self.raw_descriptors[desc_id]['data_keys']
+            for key, info in data_keys.items():
+                # Information from non-number fields is dropped
+                if info['dtype'] in ('number', 'array'):
+                    # Average together
+                    average_evt[key] = np.mean([evt['data'][key]
+                                                for evt in cache], axis=0)
+            return {'data': average_evt, 'descriptor': desc_id}
+
+        self.out_node = self.averager.map(average_events)
+        self.out_node.sink(self.process_event)
+        super().start(doc)
+
+    def event(self, doc):
+        """Send an Event through the stream"""
+        self.in_node.emit(doc)
+
+    def stop(self, doc):
+        """Delete the stream when run stops"""
+        self.in_node = None
+        self.out_node = None
+        self.averager = None
+        super().stop(doc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from bluesky import RunEngine
+import pytest
+
+
+@pytest.fixture(scope='function')
+def RE(request):
+    loop = asyncio.new_event_loop()
+    loop.set_debug(True)
+    RE = RunEngine({}, loop=loop)
+
+    def clean_event_loop():
+        if RE.state != 'idle':
+            RE.halt()
+        ev = asyncio.Event(loop=loop)
+        ev.set()
+        loop.run_until_complete(ev.wait())
+
+    request.addfinalizer(clean_event_loop)
+    return RE
+
+
+@pytest.fixture(scope='function')
+def hw():
+    from ophyd.sim import hw
+    return hw()

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,28 @@
+import logging
+
+from bluesky.callbacks import CallbackCounter
+from bluesky.plan_stubs import open_run, close_run
+import numpy as np
+
+from nabs.plan_stubs import measure_average
+
+logger = logging.getLogger(__name__)
+
+
+def test_measure_average(RE, hw):
+    logger.debug("test_measure_average")
+
+    # Pseudo-plan to measure average and check values
+    def measure_plan(detectors):
+        yield from open_run()
+        ret = yield from measure_average(detectors, num=250)
+        assert ret['motor'] == 0.0
+        assert ret['motor_setpoint'] == 0.0
+        assert np.isclose(ret['noisy_det'], 1.0, atol=0.01)
+        yield from close_run()
+
+    # Execute plan
+    cnt = CallbackCounter()
+    RE(measure_plan([hw.motor, hw.noisy_det]), {'event': [cnt]})
+    # Check that we saw the right number of events
+    assert cnt.value == 250

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,0 +1,30 @@
+from bluesky.callbacks import CallbackCounter
+from bluesky.examples import stepscan
+from bluesky.tests.utils import DocCollector
+from nabs.streams import AverageStream
+
+
+def test_average_stream(RE, hw):
+    # Create callback chain
+    avg = AverageStream(10)
+    c = CallbackCounter()
+    d = DocCollector()
+    avg.subscribe(c)
+    avg.subscribe(d.insert)
+    # Run a basic plan
+    RE(stepscan(hw.det, hw.motor), {'all': avg})
+    assert c.value == 1 + 1 + 2  # events, descriptor, start and stop
+    # See that we made sensible descriptor
+    start_uid = d.start[0]['uid']
+    assert start_uid in d.descriptor
+    desc_uid = d.descriptor[start_uid][0]['uid']
+    assert desc_uid in d.event
+    evt = d.event[desc_uid][0]
+    assert evt['seq_num'] == 1
+    assert all([key in d.descriptor[start_uid][0]['data_keys']
+                for key in evt['data'].keys()])
+    # See that we returned the correct average
+    assert evt['data']['motor'] == -0.5  # mean of range(-5, 5)
+    assert evt['data']['motor_setpoint'] == -0.5  # mean of range(-5, 5)
+    assert start_uid in d.stop
+    assert d.stop[start_uid]['num_events'] == {'primary': 1}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A replacement for `meausure_average` with newer `bluesky` tech! Excited that the plan is so short! Here is what I added.

* `AverageStream` that absorbs a stream of raw data an re-emits it as an averaged stream. This is essentially a copy of what is contained in the `bluesky` tests with the exception that I removed any dependency on `streamz`.
* `measure_average` plan that subscribes a new `AverageStream` if one is not passed in, takes a measurement and returns the last event from the stream. 

### Thoughts
* The`AverageStream` caches its last_event on itself. This allows us to return this very succinctly at the end of the plan but feel slightly hacky?
* I created two new files. Feel free to suggest names for these if you don't like "plans" and "screens"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added for both plan and stream

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings
