### PR TITLE
ENH: Filter and drop utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache
 
 # Translations
 *.mo

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -39,11 +39,11 @@ class DropWrapper:
             self.ret = {}
             self.first_read_time = None
             self.last_read_time = None
-            return None, None
         elif msg.command == 'read':
             return self._cache_read(msg), None
         elif msg.command == 'save':
             return self._filter_save(), None
+        return None, None
 
     def _cache_read(self, msg):
         if self.first_read_time is None:

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -1,0 +1,93 @@
+import logging
+import time
+
+from bluesky.plan_stubs import drop, save
+from bluesky.preprocessors import plan_mutator
+from bluesky.utils import make_decorator
+
+logger = logging.getLogger(__name__)
+
+
+class DropWrapper:
+    """
+    Replaces ``save`` messages with ``drop`` if the event is bad.
+
+    Parameters
+    ----------
+    filters: ``dict``, optional
+        A dictionary mapping from read key to function of one argument. This
+        is an "is_bad_value(value)" function that should return ``True`` if the
+        value is bad.
+
+    max_dt: ``float``, optional
+        If provided, we'll ``drop`` events if the time from before the first
+        read to after the last read is greater than this number.
+    """
+    def __init__(self, filters=None, max_dt=None):
+        self.filters = filters
+        self.max_dt = max_dt
+
+    def __call__(self, plan):
+        yield from plan_mutator(plan, self._msg_proc)
+
+    def _msg_proc(self, msg):
+        if msg.command == 'create':
+            self.ret = {}
+            self.first_read_time = None
+            self.last_read_time = None
+            return None, None
+        elif msg.command == 'read':
+            return self._cache_read(msg), None
+        elif msg.command == 'save':
+            return self._filter_save(), None
+
+    def _cache_read(self, msg):
+        if self.first_read_time is None:
+            self.first_read_time = time.time()
+        ret = yield msg
+        self.ret.update(ret)
+        self.last_read_time = time.time()
+        return ret
+
+    def _filter_save(self):
+        dt = self.last_read_time - self.first_read_time
+        if self.max_dt is not None and dt > self.max_dt:
+            logger.info(('Event took %ss to bundle, readings are desynced. '
+                         'Dropping'), dt)
+            return (yield from drop())
+        elif self.filters is not None:
+            for key, filt in self.filters.items():
+                try:
+                    value = self.ret[key]
+                except KeyError:
+                    logger.debug('Read bundle did not have filter key %s', key)
+                    value = None
+                if value is not None and filt[value]:
+                    logger.info('Event had bad value %s=%s. Dropping',
+                                key, value)
+                    return (yield from drop())
+        return (yield from save())
+
+
+def drop_wrapper(plan, filters, max_dt):
+    """
+    Replaces ``save`` messages with ``drop`` if the event is bad.
+
+    Parameters
+    ----------
+    plan: ``plan``
+        The plan to wrap.
+
+    filters: ``dict``, optional
+        A dictionary mapping from read key to function of one argument. This
+        is an "is_bad_value(value)" function that should return ``True`` if the
+        value is bad.
+
+    max_dt: ``float``, optional
+        If provided, we'll ``drop`` events if the time from before the first
+        read to after the last read is greater than this number.
+    """
+    yield from DropWrapper(filters, max_dt)(plan)
+
+
+drop_decorator = make_decorator(drop_wrapper)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 import asyncio
+import logging
 
 from bluesky import RunEngine
 import pytest
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
@@ -9,6 +12,8 @@ def RE(request):
     loop = asyncio.new_event_loop()
     loop.set_debug(True)
     RE = RunEngine({}, loop=loop)
+    RE.msg_hook = logger.debug
+    RE.verbose = True
 
     def clean_event_loop():
         if RE.state != 'idle':

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -44,13 +44,14 @@ def test_no_drop(RE_counter, hw):
     assert counter.value == 3
 
 
+@pytest.mark.timeout(3)
 def test_drop_filter(RE_counter, hw):
     logger.debug('test_drop_filter')
     RE, counter = RE_counter
 
     # Filter on det, value starts good
     def my_filter(reads):
-        return reads['det_value'] > 0.8
+        return reads['det']['value'] > 0.8
 
     RE(drop_wrapper(trigger_and_read([hw.det]), filters=my_filter))
     assert counter.value == 1
@@ -60,6 +61,7 @@ def test_drop_filter(RE_counter, hw):
     assert counter.value == 1
 
 
+@pytest.mark.timeout(3)
 def test_dt_filter(RE_counter, hw):
     logger.debug('test_dt_filter')
     RE, counter = RE_counter

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -1,0 +1,71 @@
+import logging
+
+from bluesky.callbacks import CallbackCounter
+from bluesky.plan_stubs import (trigger_and_read, create, save,
+                                trigger, read, sleep)
+from bluesky.preprocessors import run_wrapper
+import pytest
+
+from nabs.preprocessors import drop_wrapper
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='function')
+def RE_counter(RE):
+    counter = CallbackCounter()
+    RE.subscribe(counter, name='event')
+    RE.preprocessors.append(run_wrapper)
+    return RE, counter
+
+
+def gap_read(det1, det2, gap):
+    yield from create()
+    yield from trigger(det1)
+    yield from read(det1)
+    yield from sleep(gap)
+    yield from trigger(det2)
+    yield from read(det2)
+    yield from save()
+
+
+def test_no_drop(RE_counter, hw):
+    logger.debug('test_no_drop')
+    RE, counter = RE_counter
+    # Normal read
+    RE(trigger_and_read([hw.det]))
+    assert counter.value == 1
+    # Move det to "too low"
+    hw.motor.set(1)
+    RE(trigger_and_read([hw.det]))
+    assert counter.value == 2
+    # Take reads 0.5s apart
+    RE(gap_read(hw.det1, hw.det2, 0.5))
+    assert counter.value == 3
+
+
+def test_drop_filter(RE_counter, hw):
+    logger.debug('test_drop_filter')
+    RE, counter = RE_counter
+
+    # Filter on det, value starts good
+    def my_filter(reads):
+        return reads['det_value'] > 0.8
+
+    RE(drop_wrapper(trigger_and_read([hw.det]), filters=my_filter))
+    assert counter.value == 1
+    # Move det to "too low"
+    hw.motor.set(1)
+    RE(drop_wrapper(trigger_and_read([hw.det]), filters=my_filter))
+    assert counter.value == 1
+
+
+def test_dt_filter(RE_counter, hw):
+    logger.debug('test_dt_filter')
+    RE, counter = RE_counter
+    # Filter on dt, first is ok
+    RE(drop_wrapper(gap_read(hw.det1, hw.det2, 0.1), max_dt=0.4))
+    assert counter.value == 1
+    # Take reads 0.5s apart
+    RE(drop_wrapper(gap_read(hw.det1, hw.det2, 0.5), max_dt=0.4))
+    assert counter.value == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- `drop_wrapper(plan, filters, max_dt)` that will do plan, but replace `save` with `drop` if the filters say so, or if the time between first and last read in an event bundle is greater than `max_dt`. This is a "cheap" way to check we were suspended to avoid desynced event documents.
- `count_events(detectors, num, delay)` that is literally count, but if `drop_wrapper` happened it repeats the measurement until `num` event documents have been emitted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid re-implementing filter logic in every level. Utilize `drop` for great good. Abandoned the idea of trusting a `preprocessor` to cache and replay the "bad" reads, instead encapsulate this in a plan.

This means a plan like `measure_average` can use `count_events` and trust that if "someone" wants to filter at a higher level, we repeat reads that came up with bad values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests to high coverage.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
We need to make the sphinx pages for this soon, but I will defer for this PR.
<!--
## Screenshots (if appropriate):
-->
