### PR TITLE
WIP: Per-message Suspenders

### DIFF
--- a/nabs/suspenders.py
+++ b/nabs/suspenders.py
@@ -130,7 +130,7 @@ class SuspendPreprocessor:
         self._suspend_active = True
         yield from wait_for([self._ok_future])
         self._suspend_active = False
-        logger.info('Resuming plan')
+        logger.debug('resuming plan in _suspend')
         # Yield a copy of the message so we can suspend again
         # Bluesky skips preprocessor if it already saw the message
         return (yield copy.copy(msg))

--- a/nabs/suspenders.py
+++ b/nabs/suspenders.py
@@ -1,0 +1,176 @@
+import asyncio
+import logging
+from threading import RLock, Event
+
+from bluesky.plan_stubs import null, wait_for
+from bluesky.preprocessors import plan_mutator
+
+logger = logging.getLogger(__name__)
+
+
+class SuspendPreprocessor:
+    """
+    Base preprocessor that suspends on specific commands based on a signal.
+
+    Parameters
+    ----------
+    signal: ``Signal``
+        The signal to subscribe to, whose value determines when to suspend.
+
+    commands: ``list of str``, optional
+        The commands to suspend on. If omitted, we'll suspend on all commands.
+
+    sleep: ``int`` or ``float``, optional
+        The amount of time to wait after `should_resume` returns ``True``
+        before ending the suspension. If `should_suspend` return ``True`` at
+        any time during this wait period, we will cancel the resumption and
+        return to the suspended state.
+    """
+    def __init__(self, signal, *, commands=None, sleep=0,
+                 pre_plan=null, post_plan=null, follow_plan=null):
+        self._sig = signal
+        self._cmd = commands
+        self._sleep = sleep
+        self._suspend_active = False
+        self._resume_ts = None
+        self._suspend_ev = Event()
+        self._ok_future = asyncio.Future()
+        self._ok_future.set_result('ok')
+        self._rlock = RLock()
+        self._subid = None
+
+    def should_suspend(self, value):
+        """
+        Returns ``True`` if we should suspend.
+
+        Parameters
+        ----------
+        value: signal value
+            The value reported by a signal callback.
+        """
+        raise NotImplementedError()
+
+    def should_resume(self, value):
+        """
+        Returns ``True`` if we should resume.
+
+        Parameters
+        ----------
+        value: signal value
+            The value reported by a signal callback.
+        """
+        return not self.should_suspend(value)
+
+    def _update(self, *, value, **kwargs):
+        """
+        Update routine for when the signal's value changes.
+
+        If we're running normally but we should_suspend, we'll trigger the
+        suspend state. If suspended but we should_resume, we'll start a timer
+        of length sleep to clear the suspend state. This will be interrupted if
+        another value change leads us to should_suspend.
+        """
+        with self._rlock:
+            if self._suspend_ev.is_set():
+                if self.should_resume(value):
+                    self._suspend_ev.clear()
+                    self._run_release_thread()
+            else:
+                if self.should_suspend(value):
+                    logger.info('Suspending due to bad %s value=%s',
+                                self._sig.name, value)
+                    loop = asyncio.get_event_loop()
+                    self._ok_future = loop.create_future()
+                    self._suspend_ev.set()
+
+    def _run_release_thread(self):
+        logger.info('%s suspension is over, waiting for %ss then resuming.',
+                    self._sig.name, self._sleep)
+        loop = asyncio.get_event_loop()
+        loop.run_in_executor(None, self._release_thread)
+
+    def _release_thread(self):
+        logger.debug('Worker waiting to release suspender...')
+        if self._suspend_ev.wait(timeout=self._sleep):
+            logger.debug('Worker canceling suspender release')
+        else:
+            logger.debug('Worker releasing suspender')
+            self._ok_future.set_result('ok')
+
+    def __call__(self, plan):
+        """
+        Mutate plan to call self._msg_proc on each msg that comes through.
+        """
+        logger.debug('Running plan with suspender')
+        if self._subid is None:
+            self._subid = self._sig.subscribe(self._update,
+                                              event_type=self._sig.SUB_VALUE)
+        try:
+            yield from plan_mutator(plan, self._msg_proc)
+        finally:
+            if self._subid is not None:
+                self._sig.unsubscribe(self._subid)
+                self._subid = None
+
+    def _msg_proc(self, msg):
+        """
+        At each msg, decide if we should wait for a suspension to lift.
+        """
+        logger.debug('enter msg_proc')
+        with self._rlock:
+            if self._cmd is None or msg.command in self._cmd:
+                if not self._ok_future.done() and not self._suspend_active:
+                    logger.debug('saw msg_proc(%s), suspend now', msg)
+
+                    def new_gen():
+                        self._suspend_active = True
+                        yield from wait_for([self._ok_future])
+                        self._suspend_active = False
+                        logger.info('Resuming plan')
+                        yield msg
+
+                    return new_gen(), None
+            return None, None
+
+
+class BeamSuspender(SuspendPreprocessor):
+    """
+    Suspend readings on beam drop.
+
+    Parameters
+    ----------
+    beam_stats: ``BeamStats``
+        A ``pcdsdevices.beam_stats.BeamStats`` object.
+
+    min_beam: ``float``, optional keyword-only
+        The minimum allowable beam level. If the beam average drops below
+        this level, we will suspend trigger/create/read events and replay
+        unfinished event bundles. The default is 0.1.
+
+    avg: ``int``, optional keyword-only
+        The number of gas detector shots to average over.
+
+    sleep: ``int`` or ``float``, optional
+        The amount of time to wait after `should_resume` returns ``True``
+        before ending the suspension. If `should_suspend` return ``True`` at
+        any time during this wait period, we will cancel the resumption and
+        return to the suspended state.
+    """
+    def __init__(self, beam_stats, *, min_beam=0.1, avg=120, sleep=5):
+        super().__init__(beam_stats.mj_avg, sleep=sleep,
+                         commands=('trigger', 'create', 'read'))
+        self.averages = avg
+        self.min_beam = min_beam
+
+    def should_suspend(self, value):
+        if value < self.min_beam:
+            return True
+        return False
+
+    @property
+    def averages(self, avg):
+        return self._sig.averages
+
+    @averages.setter
+    def averages(self, avg):
+        self._sig.averages = avg

--- a/tests/test_suspenders.py
+++ b/tests/test_suspenders.py
@@ -1,0 +1,121 @@
+import asyncio
+import logging
+
+import pytest
+from bluesky.plan_stubs import abs_set, sleep
+from ophyd.signal import Signal
+
+from nabs.suspenders import SuspendPreprocessor
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='function')
+def sig():
+    return Signal(value=0, name='sig')
+
+
+class NonZeroSuspender(SuspendPreprocessor):
+    """
+    Suspend on nonzero signal
+    """
+    def should_suspend(self, value):
+        return value
+
+
+def basic_plan(n, sleep_time):
+    for i in range(n):
+        yield from sleep(sleep_time)
+
+
+def wait_for_future(future):
+    """
+    Use in tests without RE to avoid race conditions
+    """
+    logger.debug('waiting for future')
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(asyncio.wait([future], loop=loop))
+    logger.debug('done waiting for future')
+
+
+def assert_suspend_release(plan, susp, sig):
+    sig.put(1)
+    assert susp._suspend_ev.is_set()
+    # Suspend
+    assert next(plan).command == 'wait_for'
+    sig.put(0)
+    wait_for_future(susp._ok_future)
+
+
+def assert_plan_done(plan):
+    with pytest.raises(StopIteration):
+        next(plan)
+
+
+@pytest.mark.timeout(3)
+def test_suspend_basic(sig):
+    logger.debug('test_suspend_basic')
+    susp = NonZeroSuspender(sig, sleep=0.1)
+
+    def test_plan():
+        yield from basic_plan(3, 1)
+
+    # Dry run
+    for msg in susp(test_plan()):
+        assert msg.command == 'sleep'
+
+    # Suspend before the second sleep
+    plan = susp(test_plan())
+    assert next(plan).command == 'sleep'
+    assert_suspend_release(plan, susp, sig)
+    assert next(plan).command == 'sleep'
+    assert next(plan).command == 'sleep'
+    assert_plan_done(plan)
+
+
+@pytest.mark.timeout(3)
+def test_suspend_cmd(sig):
+    logger.debug('test_suspend_cmd')
+    susp = NonZeroSuspender(sig, commands=['set'])
+
+    def test_plan():
+        yield from basic_plan(3, 1)
+        yield from abs_set(sig, 0)
+
+    # Dry run
+    cmds = [msg.command for msg in list(susp(test_plan()))]
+    assert cmds == ['sleep', 'sleep', 'sleep', 'set']
+
+    # Trip the suspender immediately, make sure we skip suspending until set
+    plan = susp(test_plan())
+    sig.put(1)
+    for i in range(3):
+        assert next(plan).command == 'sleep'
+    assert_suspend_release(plan, susp, sig)
+    assert next(plan).command == 'set'
+    assert_plan_done(plan)
+
+
+@pytest.mark.timeout(3)
+def test_suspend_in_follow_up(sig):
+    logger.debug('test_suspend_in_follow_up')
+    susp = NonZeroSuspender(sig)
+
+    def test_plan():
+        yield from basic_plan(2, 1)
+
+    plan = susp(test_plan())
+    assert next(plan).command == 'sleep'
+    assert_suspend_release(plan, susp, sig)
+    # Suspend before redoing old message
+    assert_suspend_release(plan, susp, sig)
+    # Back to plan
+    assert next(plan).command == 'sleep'
+    assert_plan_done(plan)
+
+
+def test_needs_override():
+    logger.debug('test_needs_override')
+    susp = SuspendPreprocessor(None)
+    with pytest.raises(NotImplementedError):
+        susp.should_suspend(None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Re-imagining of suspenders as a preprocessor. Seems to do what I intend but definitely still in the experimental phase. This will monitor a signal and halt the plan on particular messages until the signal reaches a good value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Finer control over when to suspend (only on reads? only on moves?)
- No chance of multi-suspensions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
WIP
<!--
## Screenshots (if appropriate):
-->
