### PR TITLE
ENH: monitor_scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vim
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *.cover

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -1,19 +1,53 @@
 import asyncio
+import logging
 
 from bluesky.callbacks import CallbackCounter
+
+logger = logging.getLogger(__name__)
 
 
 class CallbackCounterFuture(CallbackCounter):
     """
-    A callback counter that marks a Future when the count reaches max_count
+    A callback counter that marks a Future when the count reaches max_count.
+
+    This will wait to recieve the number of events related to each of the
+    given detectors. Some detectors may get extra events, but this will
+    wait until they all have enough.
+
+    Parameters
+    ----------
+    max_count: ``int``
+        The number of events to wait for
+    detectors: ``list``, optional
+        The detectors to wait for events on. If omitted, we'll just wait
+        for a total number of events.
     """
-    def __init__(self, max_count):
+    def __init__(self, max_count, detectors=None):
         super().__init__(self)
         self.max_count = max_count
+        if detectors is None:
+            self.dets = None
+        else:
+            self.dets = {det.name: 0 for det in detectors}
         loop = asyncio.get_event_loop()
         self.future = loop.create_future()
 
     def __call__(self, name, doc):
         super().__call__(self, name, doc)
-        if self.value >= self.max_count and not self.future.done():
-            self.future.set_result('reached {}'.format(self.value))
+        if not self.future.done():
+            if self.dets is None:
+                if self.value >= self.max_count:
+                    self.future.set_result('reached {}'.format(self.value))
+            else:
+                try:
+                    data = doc['data']
+                except KeyError:
+                    logger.debug(('used detectors arg and had callback on '
+                                  'non-event doc'))
+                    return
+                for name in self.dets.keys():
+                    if name in data:
+                        self.dets[name] += 1
+                if all(val >= self.max_count for val in self.dets.values()):
+                    self.future.set_result(('reached {} for all '
+                                            'dets'.format(self.max_count)))

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from bluesky.callbacks import CallbackCounter
+
+
+class CallbackCounterFuture(CallbackCounter):
+    """
+    A callback counter that marks a Future when the count reaches max_count
+    """
+    def __init__(self, max_count):
+        super().__init__(self)
+        self.max_count = max_count
+        loop = asyncio.get_event_loop()
+        self.future = loop.create_future()
+
+    def __call__(self, name, doc):
+        super().__call__(self, name, doc)
+        if self.value >= self.max_count and not self.future.done():
+            self.future.set_result('reached {}'.format(self.value))

--- a/nabs/plan_stubs.py
+++ b/nabs/plan_stubs.py
@@ -1,9 +1,13 @@
 import logging
 
 from bluesky.plans import count
-from bluesky.plan_stubs import subscribe
+from bluesky.plan_stubs import (subscribe, unsubscribe, monitor, unmonitor,
+                                sleep, checkpoint, abs_set, wait as wait_uid,
+                                wait_for as wait_future)
 from bluesky.preprocessors import stub_wrapper
+from bluesky.utils import short_uid
 
+from nabs.callbacks import CallbackCounterFuture
 from nabs.streams import AverageStream
 
 
@@ -60,3 +64,63 @@ def measure_average(detectors, num, delay=None, stream=None):
     yield from stub_wrapper(count(detectors, num=num, delay=delay))
     # Return the measured average as a dictionary for use in adaptive plans
     return stream.last_event
+
+
+def move_per_step(detectors, step, pos_cache):
+    """
+    The motion portion of the per_step hook.
+
+    Use this inside of other per_step hooks to avoid rewriting the move part.
+    """
+    yield from checkpoint()
+    grp = short_uid('set')
+    for motor, pos in step.items():
+        if pos == pos_cache[motor]:
+            continue
+        yield from abs_set(motor, pos, group=grp)
+        pos_cache[motor] = pos
+    yield from wait_uid(group=grp)
+
+
+def monitor_step(events=None, duration=None):
+    """
+    Create bluesky per_step hook for monitoring detectors at every point.
+
+    Parameters
+    ----------
+    events: ``int``, optional
+        If provided, we'll monitor until we have enough events.
+    duration: ``float``, optional
+        If provided, we'll monitor for this fixed duration in seconds.
+        If both arguments are provided, then we'll wait for both to be true,
+        so we'll have a minimum elapsed time and a minimum number of events.
+
+    Returns
+    -------
+    inner_monitor_step: ``function``
+        A function that is usable as a bluesky per_step hook
+    """
+    if events is None and duration is None:
+        raise ValueError(('Must pass events or duration kwarg to '
+                          'monitor_step'))
+
+    def inner_monitor_step(detectors, step, pos_cache):
+        yield from move_per_step(detectors, step, pos_cache)
+
+        if events is not None:
+            counter = CallbackCounterFuture(events)
+            sub_id = yield from subscribe(counter, 'event')
+
+        for det in detectors:
+            yield from monitor(det)
+
+        if duration is not None:
+            yield from sleep(duration)
+        if events is not None:
+            yield from wait_future(counter.future)
+            yield from unsubscribe(sub_id)
+
+        for det in detectors:
+            yield from unmonitor(det)
+
+    return inner_monitor_step

--- a/nabs/plan_stubs.py
+++ b/nabs/plan_stubs.py
@@ -104,7 +104,8 @@ def monitor_events(detectors, events=None, duration=None):
     """
     if events is not None:
         counter = CallbackCounterFuture(events, detectors)
-        sub_id = yield from subscribe(counter, 'event')
+        counter.ensure_future()
+        sub_id = yield from subscribe('event', counter)
 
     for det in detectors:
         yield from monitor(det)
@@ -112,7 +113,7 @@ def monitor_events(detectors, events=None, duration=None):
     if duration is not None:
         yield from sleep(duration)
     if events is not None:
-        yield from wait_future(counter.future)
+        yield from wait_future([counter.future])
         yield from unsubscribe(sub_id)
 
     for det in detectors:

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -1,0 +1,44 @@
+from bluesky.plans import scan
+
+from .plan_stubs import monitor_step
+
+
+def monitor_scan(detectors, *args, num=None, events=None, duration=None,
+                 md=None):
+    """
+    Scan over a multi-motor trajectory for number of epics events or duration.
+
+    Either events, duration, or both must be provided. If both are provided,
+    we'll wait for both a number of events and a duration, not moving on
+    until both are satisfied.
+
+    The events counter applies to all detectors.
+
+    Parameters
+    ----------
+    detectors : list
+        list of 'readable' objects
+    *args :
+        For one dimension, ``motor, start, stop``.
+        In general:
+
+        .. code-block:: python
+
+            motor1, start1, stop1,
+            motor2, start2, start2,
+            ...,
+            motorN, startN, stopN
+
+        Motors can be any 'settable' object (motor, temp controller, etc.)
+    num : integer
+        number of points
+    events : ``int``, optional
+        The number of epics updates to monitor for at each point.
+    duration : ``float``, optional
+        The fixed duration in seconds to monitor for at each point.
+    md : dict, optional
+        metadata
+    """
+    # I was also surprised this became a 2-liner
+    per_step = monitor_step(events=events, duration=duration)
+    yield from scan(detectors, *args, num=num, per_step=per_step, md=md)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,64 @@
+import logging
+
+from bluesky.plan_stubs import (open_run, close_run, trigger_and_read,
+                                wait_for, monitor, unmonitor)
+import pytest
+
+from nabs.callbacks import CallbackCounterFuture
+
+logger = logging.getLogger(__name__)
+
+
+def batch_mon(detectors):
+    for det in detectors:
+        yield from monitor(det)
+
+
+def batch_unmon(detectors):
+    for det in detectors:
+        yield from unmonitor(det)
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize('num_calls', [1, 10])
+@pytest.mark.parametrize('num_dets', [1, 3])
+@pytest.mark.parametrize('counting', ['each', 'total'])
+@pytest.mark.parametrize('method', ['read', 'monitor'])
+def test_counter_future(RE, hw, num_calls, num_dets, counting, method):
+    logger.debug('test_counter_future')
+    dets = [hw.det1, hw.det2, hw.det3]
+    dets = dets[:num_dets]
+    if counting == 'total':
+        counter = CallbackCounterFuture(num_calls)
+        RE.subscribe(counter, 'event')
+    elif counting == 'each':
+        counter = CallbackCounterFuture(num_calls, detectors=dets)
+        RE.subscribe(counter)
+
+    def plan():
+        yield from open_run()
+        i = 0
+        if method == 'monitor':
+            yield from batch_mon(dets)
+        while True:
+            i += 1
+            if method == 'read':
+                yield from trigger_and_read(dets)
+            elif method == 'monitor':
+                for det in dets:
+                    det.put(i)
+            logger.debug(counter.value)
+            if counter.future.done():
+                break
+        if method == 'monitor':
+            yield from batch_unmon(dets)
+        assert counter.future.done()
+        # make sure we can use it with the RE's loop
+        yield from wait_for([counter.future])
+        yield from close_run()
+
+    RE(plan())
+    if counting == 'each':
+        assert counter.dets == {det.name: num_calls for det in dets}
+    elif counting == 'total':
+        assert num_calls <= counter.value < num_calls + num_dets

--- a/tests/test_plan_stubs.py
+++ b/tests/test_plan_stubs.py
@@ -1,10 +1,12 @@
 import logging
+import time
 
-from bluesky.callbacks import CallbackCounter
+from bluesky.callbacks import CallbackCounter, collector
 from bluesky.plan_stubs import open_run, close_run
 import numpy as np
+import pytest
 
-from nabs.plan_stubs import measure_average
+from nabs.plan_stubs import measure_average, monitor_events
 
 logger = logging.getLogger(__name__)
 
@@ -26,3 +28,47 @@ def test_measure_average(RE, hw):
     RE(measure_plan([hw.motor, hw.noisy_det]), {'event': [cnt]})
     # Check that we saw the right number of events
     assert cnt.value == 250
+
+
+@pytest.mark.timeout(10)
+def test_monitor_events(RE, hw):
+    logger.debug('test_monitor_events')
+
+    def plan(detectors, events=None, duration=None):
+        yield from open_run()
+        yield from monitor_events(detectors, events=events, duration=duration)
+        yield from close_run()
+
+    detectors = [hw.det]
+
+    # should take about 0.3s
+    start = time.time()
+    RE(plan(detectors, duration=0.3))
+    delta = time.time() - start
+    assert 0.3 < delta < 1.3
+
+    for det in detectors:
+        det.put(0)
+
+    def bg(loop):
+        logger.debug('bg')
+        for det in detectors:
+            value = det.get()
+            det.put(value + 1)
+        logger.debug(value)
+        if value < 10:
+            loop.call_later(0.1, bg, loop)
+
+    def plan_bg(detectors, events=None, duration=None):
+        loop = RE._loop
+        loop.call_later(0.1, bg, loop)
+        yield from plan(detectors, events=events, duration=duration)
+
+    det_vals = []
+    coll = collector(detectors[0].name, det_vals)
+    RE.subscribe(coll, 'event')
+
+    RE(plan_bg(detectors, events=7))
+    assert len(det_vals) >= 7
+    for det in detectors:
+        assert det.value < 10

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -34,11 +34,15 @@ def test_monitor_scan(RE, hw):
 
     n_mot = 0
     n_det = 0
+    mot_pos = []
     for doc in docs:
         if hw.motor.name in doc['data']:
             n_mot += 1
+            mot_pos.append(doc['data'][hw.motor.name])
         if hw.det.name in doc['data']:
             n_det += 1
 
     assert n_mot == num_steps
     assert n_det == num_steps * events
+    assert min(mot_pos) == -3
+    assert max(mot_pos) == 3

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,44 @@
+import logging
+
+from ophyd.status import wait as status_wait
+import pytest
+
+from nabs.plans import monitor_scan
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.timeout(5)
+def test_monitor_scan(RE, hw):
+    logger.debug('test_monitor_scan')
+    num_steps = 11
+    events = 3
+    docs = []
+
+    def collect_docs(name, doc):
+        logger.debug('collect %s %s', name, doc)
+        docs.append(doc)
+    RE.subscribe(collect_docs, 'event')
+
+    def trigger_det_outer(*args, **kwargs):
+        RE._loop.call_later(0.1, trigger_det)
+
+    def trigger_det(*args, **kwargs):
+        logger.debug('trigger')
+        for i in range(events - 1):
+            status_wait(hw.det.trigger())
+
+    hw.motor.readback.subscribe(trigger_det_outer, run=False)
+    hw.det.trigger()
+    RE(monitor_scan([hw.det], hw.motor, -3, 3, num_steps, events=events))
+
+    n_mot = 0
+    n_det = 0
+    for doc in docs:
+        if hw.motor.name in doc['data']:
+            n_mot += 1
+        if hw.det.name in doc['data']:
+            n_det += 1
+
+    assert n_mot == num_steps
+    assert n_det == num_steps * events


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add full plan `monitor_scan` and the intermediates/helpers I needed to implement it. 

I'm not entirely in love with this implementation, but it's good enough for discussion. The problem is that the monitored event streams are not correlated with other points, so, for example, a callback will need to pick which motor positions to match the monitored stream with to do a proper plot. I think callbacks in general for monitored values will need to be slightly smarter.

I'd want to pair this with a plotting callback that plots the scattered range up the y-axis against the last read motor position on the x axis.

The documents look something like like:
> start
> descriptor(all motors)
> event(all motors)
> descriptor(det1)
> event(det1)
> descriptor(det2)
> event(det2)
{
> event(det1)
> event(det2)
} x N - 1
> event(all motors)
...
lots of repeating
...
> end

I may also need to do some additional manipulation of the metadata dictionary...


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/pcdshub/hutch-python/issues/118
The idea is to be able to take data over a time period or to have more efficient scans by monitoring up to an events count instead of polling.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for coverage

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Needs to be written

<!--
## Screenshots (if appropriate):
-->
