### PR TITLE
HACK: tweak signature of step plans for bs gui

### DIFF
--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -8,6 +8,8 @@ and yield messages from a new, modified plan, as well as "decorator"
 functions that can be applied to ``bluesky`` plan functions to return new
 plan functions with modifications.
 """
+import inspect
+
 from functools import wraps
 
 import bluesky.plan_stubs as bps
@@ -197,16 +199,32 @@ def daq_step_scan_decorator(plan):
     """
 
     @wraps(plan)
-    def inner(*args, **kwargs):
-        events = kwargs.pop('events', None)
-        duration = kwargs.pop('duration', None)
-        record = kwargs.pop('record', True)
-        use_l3t = kwargs.pop('use_l3t', False)
+    def inner(*args, events=None, duration=None, record=True, use_l3t=False):
         return (yield from daq_step_scan_wrapper(plan(*args, **kwargs),
                                                  events=events,
                                                  duration=duration,
                                                  record=record,
                                                  use_l3t=use_l3t))
+
+    def helper_sig(*args, events=None, duration=None, record=True, use_l3t=False):
+        ...
+
+    sig = inspect.signature(plan)
+    params = list(sig.parameters.values())
+    keyword_only = [idx for idx, param in enumerate(params) if param.kind.name == 'KEYWORD_ONLY']
+    if not keyword_only:
+        start_params, end_params = params, []
+    else:
+        insert_at = keyword_only[0]
+        start_params, end_params = params[:insert_at], params[insert_at:]
+
+    wrapper_params = list(
+        param for param in list(inspect.signature(helper_sig).parameters.values())[1:]
+        if param.name not in sig.parameters
+    )
+
+    params = start_params + wrapper_params + end_params
+    plan.__signature__ = sig.replace(parameters=params)
     return inner
 
 

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -1,3 +1,6 @@
+import inspect
+from typing import Any, Callable, Dict, Union
+
 from ophyd.signal import DerivedSignal, SignalRO
 
 
@@ -59,3 +62,51 @@ class ErrorSignal(SignalRO, DerivedSignal):
 
     def trigger(self):
         return self.derived_from.trigger()
+
+
+def add_named_kwargs_to_signature(
+    func_or_signature: Union[inspect.Signature, Callable],
+    kwargs: Dict[str, Any]
+) -> inspect.Signature:
+    """
+    Add named keyword arguments with default values to a function signature.
+
+    Parameters
+    ----------
+    func_or_signature : inspect.Signature or callable
+        The function or signature.
+
+    kwargs : dict
+        The dictionary of kwarg_name to default_value.
+
+    Returns
+    -------
+    modified_signature : inspect.Signature
+        The modified signature with additional keyword arguments.
+    """
+
+    if isinstance(func_or_signature, inspect.Signature):
+        sig = func_or_signature
+    else:
+        sig = inspect.signature(func_or_signature)
+
+    params = list(sig.parameters.values())
+    keyword_only_indices = [
+        idx for idx, param in enumerate(params)
+        if param.kind == inspect.Parameter.KEYWORD_ONLY
+    ]
+    if not keyword_only_indices:
+        start_params, end_params = params, []
+    else:
+        insert_at = keyword_only_indices[0]
+        start_params, end_params = params[:insert_at], params[insert_at:]
+
+    wrapper_params = list(
+        inspect.Parameter(
+            name, kind=inspect.Parameter.KEYWORD_ONLY, default=value
+        )
+        for name, value in kwargs.items()
+        if name not in sig.parameters
+    )
+
+    return sig.replace(parameters=start_params + wrapper_params + end_params)


### PR DESCRIPTION
End goal is this:

```
In [2]: inspect.signature(nabs.plans.daq_dscan)
Out[2]: <Signature (detectors, motor, start, end, nsteps, *, events=None, duration=None, record=True, use_l3t=False)>
```

I'd bet there's a one/two liner out there that'll do this. But it's Friday and I'm not finding it. Also did not make an effort to clean this up before pushing because it's already 5:30, and I haven't really even eaten lunch yet. 

(Don't merge until we figure out if this is really the best we can do)

cc @cristinasewell 