### PR TITLE
MNT: prospective fix for duplicate keys in daq scan

### DIFF
--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -162,8 +162,6 @@ def daq_step_scan_wrapper(plan, events=None, duration=None, record=True,
         # Strip redundant DAQ stages from inner plan
         elif msg.command in ('stage', 'unstage') and msg.obj is daq:
             return drop_daq_msg(msg), None
-        elif msg.command == 'stage' and is_movable(msg.obj):
-            motor_cache.add(msg.obj)
         # If didn't mutate, return the (None, None) signal for plan_mutator
         return None, None
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove the check for adding "staged" devices to the daq controls list, instead only including devices that we "set" (move) before the first reading.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using "stage" was done as a measure to include as many relevant devices as possible, but that's not what we want. In fact, since staging also stages parents and children, it means that we can get duplicate keys in the controls list if the parent and child devices are both movable.

With the assumption that all devices we care about are moved before the first reading, this should always give us the correct list of controls to automatically pass to the LCLS1 DAQ.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
WIP

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
