### PR TITLE
Daq d2scan, n-dimensional daq_anscan, daq_dnscan

### DIFF
--- a/docs/source/upcoming_release_notes/49-daq_d2scan.rst
+++ b/docs/source/upcoming_release_notes/49-daq_d2scan.rst
@@ -1,0 +1,23 @@
+49 daq_d2scan
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add daq_d2scan
+- Add n-dimensional daq scans: daq_dnscan, daq_anscan
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- roberttk

--- a/docs/source/upcoming_release_notes/49-daq_d2scan.rst
+++ b/docs/source/upcoming_release_notes/49-daq_d2scan.rst
@@ -20,4 +20,4 @@ Maintenance
 
 Contributors
 ------------
-- roberttk
+- tangkong

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -617,6 +617,7 @@ def daq_a2scan(detectors, m1, a1, b1, m2, a2, b2, nsteps):
 
     yield from bp.scan(detectors, m1, a1, b1, m2, a2, b2, nsteps)
 
+
 @bpp.reset_positions_decorator()
 @bpp.relative_set_decorator()
 @nbpp.daq_step_scan_decorator
@@ -624,8 +625,8 @@ def daq_d2scan(detectors, m1, a1, b1, m2, a2, b2, nsteps):
     """
     Two-dimensional daq scan with relative positions
 
-    This moves two motors from start to end relative to their current positions 
-    in nsteps steps, taking data in the DAQ at every step, and returning the 
+    This moves two motors from start to end relative to their current positions
+    in nsteps steps, taking data in the DAQ at every step, and returning the
     motors to their original positions at the end of the scan.
 
     Parameters
@@ -676,6 +677,7 @@ def daq_d2scan(detectors, m1, a1, b1, m2, a2, b2, nsteps):
     :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
     """
     yield from bp.scan(detectors, m1, a1, b1, m2, a2, b2, nsteps)
+
 
 @bpp.reset_positions_decorator()
 @nbpp.daq_step_scan_decorator
@@ -746,6 +748,7 @@ def daq_a3scan(detectors, m1, a1, b1, m2, a2, b2, m3, a3, b3, nsteps):
 
     yield from bp.scan(detectors, m1, a1, b1, m2, a2, b2, m3, a3, b3, nsteps)
 
+
 @bpp.reset_positions_decorator()
 @nbpp.daq_step_scan_decorator
 def daq_anscan(detectors, *args):
@@ -756,11 +759,11 @@ def daq_anscan(detectors, *args):
     the DAQ at every step, and returning the motors to their original positions
     at the end of the scan.
 
-    Takes an arbitrary number of motors, start and stop positions 
+    Takes an arbitrary number of motors, start and stop positions
 
-    >> RE(daq_anscan([], m1, a1, b1, 
-                         m2, a2, b2, ... , 
-                         mn, an, bn, nsteps, 
+    >> RE(daq_anscan([], m1, a1, b1,
+                         m2, a2, b2, ... ,
+                         mn, an, bn, nsteps,
                          events=10))
 
     Parameters
@@ -803,6 +806,7 @@ def daq_anscan(detectors, *args):
     """
     yield from bp.scan(detectors, *args)
 
+
 @bpp.reset_positions_decorator()
 @bpp.relative_set_decorator()
 @nbpp.daq_step_scan_decorator
@@ -814,11 +818,11 @@ def daq_dnscan(detectors, *args):
     the DAQ at every step, and returning the motors to their original positions
     at the end of the scan.
 
-    Takes an arbitrary number of motors, start and stop positions 
+    Takes an arbitrary number of motors, start and stop positions
 
-    >> RE(daq_dnscan([], m1, a1, b1, 
-                         m2, a2, b2, ... , 
-                         mn, an, bn, nsteps, 
+    >> RE(daq_dnscan([], m1, a1, b1,
+                         m2, a2, b2, ... ,
+                         mn, an, bn, nsteps,
                          events=10))
 
     Parameters
@@ -860,6 +864,7 @@ def daq_dnscan(detectors, *args):
     :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
     """
     yield from bp.scan(detectors, *args)
+
 
 def fixed_target_scan(sample, detectors, x_motor, y_motor, scan_motor, ss,
                       n_shots, path):

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -617,6 +617,65 @@ def daq_a2scan(detectors, m1, a1, b1, m2, a2, b2, nsteps):
 
     yield from bp.scan(detectors, m1, a1, b1, m2, a2, b2, nsteps)
 
+@bpp.reset_positions_decorator()
+@bpp.relative_set_decorator()
+@nbpp.daq_step_scan_decorator
+def daq_d2scan(detectors, m1, a1, b1, m2, a2, b2, nsteps):
+    """
+    Two-dimensional daq scan with relative positions
+
+    This moves two motors from start to end relative to their current positions 
+    in nsteps steps, taking data in the DAQ at every step, and returning the 
+    motors to their original positions at the end of the scan.
+
+    Parameters
+    ----------
+    detectors : list of readables
+        Objects to read into Python in the scan.
+
+    m1 : Movable
+        The first movable object to scan.
+
+    a1 : int or float
+        The first point in the scan for m1, relative to the current position.
+
+    b1 : int or float
+        The last point in the scan for m1, relative to the current position.
+
+    m2 : Movable
+        The second movable object to scan.
+
+    a2 : int or float
+        The first point in the scan for m2, relative to the current position.
+
+    b2 : int or float
+        The last point in the scan for m2, relative to the current position.
+
+    nsteps : int
+        The number of points in the scan.
+
+    events : int, optional
+        Number of events to take at each step. If omitted, uses the
+        duration argument or the last configured value.
+
+    duration : int or float, optional
+        Duration of time to spend at each step. If omitted, uses the events
+        argument or the last configured value.
+
+    record : bool, optional
+        Whether or not to record the run in the DAQ. Defaults to True because
+        we don't want to accidentally skip recording good runs.
+
+    use_l3t : bool, optional
+        Whether or not the use the l3t filter for the events argument. Defaults
+        to False to avoid confusion from unconfigured filters.
+
+    Note
+    ----
+    The events, duration, record, and use_l3t arguments come from the
+    :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
+    """
+    yield from bp.scan(detectors, m1, a1, b1, m2, a2, b2, nsteps)
 
 @bpp.reset_positions_decorator()
 @nbpp.daq_step_scan_decorator
@@ -687,6 +746,61 @@ def daq_a3scan(detectors, m1, a1, b1, m2, a2, b2, m3, a3, b3, nsteps):
 
     yield from bp.scan(detectors, m1, a1, b1, m2, a2, b2, m3, a3, b3, nsteps)
 
+@bpp.reset_positions_decorator()
+@nbpp.daq_step_scan_decorator
+def daq_anscan(detectors, *args):
+    """
+    N-dimensional daq scan with absolute positions.
+
+    This moves N motors from start to end in nsteps steps, taking data in
+    the DAQ at every step, and returning the motors to their original positions
+    at the end of the scan.
+
+    Takes an arbitrary number of motors, start and stop positions 
+
+    >> RE(daq_anscan([det, daq], m1, a1, b1, 
+                                 m2, a2, b2, ... , 
+                                 mn, an, bn, nsteps))
+
+    Parameters
+    ----------
+    detectors : list of readables
+        Objects to read into Python in the scan.
+
+    m1 : Movable
+        The first movable object to scan.
+
+    a1 : int or float
+        The first point in the scan for m1.
+
+    b1 : int or float
+        The last point in the scan for m1.
+
+    nsteps : int
+        The number of points in the scan.
+
+    events : int, optional
+        Number of events to take at each step. If omitted, uses the
+        duration argument or the last configured value.
+
+    duration : int or float, optional
+        Duration of time to spend at each step. If omitted, uses the events
+        argument or the last configured value.
+
+    record : bool, optional
+        Whether or not to record the run in the DAQ. Defaults to True because
+        we don't want to accidentally skip recording good runs.
+
+    use_l3t : bool, optional
+        Whether or not the use the l3t filter for the events argument. Defaults
+        to False to avoid confusion from unconfigured filters.
+
+    Note
+    ----
+    The events, duration, record, and use_l3t arguments come from the
+    :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
+    """
+    yield from bp.scan(detectors, *args)
 
 def fixed_target_scan(sample, detectors, x_motor, y_motor, scan_motor, ss,
                       n_shots, path):

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -758,9 +758,10 @@ def daq_anscan(detectors, *args):
 
     Takes an arbitrary number of motors, start and stop positions 
 
-    >> RE(daq_anscan([det, daq], m1, a1, b1, 
-                                 m2, a2, b2, ... , 
-                                 mn, an, bn, nsteps))
+    >> RE(daq_anscan([], m1, a1, b1, 
+                         m2, a2, b2, ... , 
+                         mn, an, bn, nsteps, 
+                         events=10))
 
     Parameters
     ----------
@@ -775,6 +776,64 @@ def daq_anscan(detectors, *args):
 
     b1 : int or float
         The last point in the scan for m1.
+
+    nsteps : int
+        The number of points in the scan.
+
+    events : int, optional
+        Number of events to take at each step. If omitted, uses the
+        duration argument or the last configured value.
+
+    duration : int or float, optional
+        Duration of time to spend at each step. If omitted, uses the events
+        argument or the last configured value.
+
+    record : bool, optional
+        Whether or not to record the run in the DAQ. Defaults to True because
+        we don't want to accidentally skip recording good runs.
+
+    use_l3t : bool, optional
+        Whether or not the use the l3t filter for the events argument. Defaults
+        to False to avoid confusion from unconfigured filters.
+
+    Note
+    ----
+    The events, duration, record, and use_l3t arguments come from the
+    :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
+    """
+    yield from bp.scan(detectors, *args)
+
+@bpp.reset_positions_decorator()
+@bpp.relative_set_decorator()
+@nbpp.daq_step_scan_decorator
+def daq_dnscan(detectors, *args):
+    """
+    N-dimensional daq scan with relative positions.
+
+    This moves N motors from start to end in nsteps steps, taking data in
+    the DAQ at every step, and returning the motors to their original positions
+    at the end of the scan.
+
+    Takes an arbitrary number of motors, start and stop positions 
+
+    >> RE(daq_dnscan([], m1, a1, b1, 
+                         m2, a2, b2, ... , 
+                         mn, an, bn, nsteps, 
+                         events=10))
+
+    Parameters
+    ----------
+    detectors : list of readables
+        Objects to read into Python in the scan.
+
+    m1 : Movable
+        The first movable object to scan.
+
+    a1 : int or float
+        The first point in the scan for m1, relative to the current position.
+
+    b1 : int or float
+        The last point in the scan for m1, relative to the current position.
 
     nsteps : int
         The number of points in the scan.

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -208,6 +208,41 @@ def test_daq_d2scan(RE, daq, hw):
                                      hw.motor2, 0, 10, 11,
                                      events=1))
 
+@pytest.mark.timeout(PLAN_TIMEOUT)
+def test_daq_anscan(RE, daq, hw):
+    logger.debug('test_daq_anscan')
+    daq_test(RE, daq, nbp.daq_anscan([hw.det],
+                                    hw.motor1, 0, 10, 11,
+                                    events=1))
+
+    daq_test(RE, daq, nbp.daq_anscan([hw.det],
+                                    hw.motor1, 0, 10,
+                                    hw.motor2, 0, 10, 11,
+                                    events=1))                                 
+
+    daq_test(RE, daq, nbp.daq_anscan([hw.det],
+                                     hw.motor1, 0, 10,
+                                     hw.motor2, 0, 10,
+                                     hw.motor3, 0, 10, 11,
+                                     events=1))
+
+@pytest.mark.timeout(PLAN_TIMEOUT)
+def test_daq_anscan(RE, daq, hw):
+    logger.debug('test_daq_anscan')
+    daq_test(RE, daq, nbp.daq_dnscan([hw.det],
+                                    hw.motor1, 0, 10, 11,
+                                    events=1))
+
+    daq_test(RE, daq, nbp.daq_dnscan([hw.det],
+                                    hw.motor1, 0, 10,
+                                    hw.motor2, 0, 10, 11,
+                                    events=1))                                 
+
+    daq_test(RE, daq, nbp.daq_dnscan([hw.det],
+                                     hw.motor1, 0, 10,
+                                     hw.motor2, 0, 10,
+                                     hw.motor3, 0, 10, 11,
+                                     events=1))
 
 @pytest.mark.timeout(PLAN_TIMEOUT)
 def test_fixed_target_scan(RE, hw, sample_file):

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -3,11 +3,12 @@ from collections import defaultdict
 
 import numpy as np
 import pytest
+from bluesky.simulators import summarize_plan
 from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
 from pcdsdevices.pseudopos import DelayBase
 from pcdsdevices.sim import FastMotor
-from bluesky.simulators import summarize_plan
+
 import nabs.plans as nbp
 
 PLAN_TIMEOUT = 60
@@ -200,6 +201,7 @@ def test_daq_a3scan(RE, daq, hw):
                                      hw.motor3, 0, 10, 11,
                                      events=1))
 
+
 @pytest.mark.timeout(PLAN_TIMEOUT)
 def test_daq_d2scan(RE, daq, hw):
     logger.debug('test_daq_d2scan')
@@ -208,41 +210,44 @@ def test_daq_d2scan(RE, daq, hw):
                                      hw.motor2, 0, 10, 11,
                                      events=1))
 
-@pytest.mark.timeout(PLAN_TIMEOUT)
-def test_daq_anscan(RE, daq, hw):
-    logger.debug('test_daq_anscan')
-    daq_test(RE, daq, nbp.daq_anscan([hw.det],
-                                    hw.motor1, 0, 10, 11,
-                                    events=1))
-
-    daq_test(RE, daq, nbp.daq_anscan([hw.det],
-                                    hw.motor1, 0, 10,
-                                    hw.motor2, 0, 10, 11,
-                                    events=1))                                 
-
-    daq_test(RE, daq, nbp.daq_anscan([hw.det],
-                                     hw.motor1, 0, 10,
-                                     hw.motor2, 0, 10,
-                                     hw.motor3, 0, 10, 11,
-                                     events=1))
 
 @pytest.mark.timeout(PLAN_TIMEOUT)
 def test_daq_anscan(RE, daq, hw):
     logger.debug('test_daq_anscan')
+    daq_test(RE, daq, nbp.daq_anscan([hw.det],
+             hw.motor1, 0, 10, 11,
+             events=1))
+
+    daq_test(RE, daq, nbp.daq_anscan([hw.det],
+             hw.motor1, 0, 10,
+             hw.motor2, 0, 10, 11,
+             events=1))
+
+    daq_test(RE, daq, nbp.daq_anscan([hw.det],
+             hw.motor1, 0, 10,
+             hw.motor2, 0, 10,
+             hw.motor3, 0, 10, 11,
+             events=1))
+
+
+@pytest.mark.timeout(PLAN_TIMEOUT)
+def test_daq_dnscan(RE, daq, hw):
+    logger.debug('test_daq_dnscan')
     daq_test(RE, daq, nbp.daq_dnscan([hw.det],
-                                    hw.motor1, 0, 10, 11,
-                                    events=1))
+             hw.motor1, 0, 10, 11,
+             events=1))
 
     daq_test(RE, daq, nbp.daq_dnscan([hw.det],
-                                    hw.motor1, 0, 10,
-                                    hw.motor2, 0, 10, 11,
-                                    events=1))                                 
+             hw.motor1, 0, 10,
+             hw.motor2, 0, 10, 11,
+             events=1))
 
     daq_test(RE, daq, nbp.daq_dnscan([hw.det],
-                                     hw.motor1, 0, 10,
-                                     hw.motor2, 0, 10,
-                                     hw.motor3, 0, 10, 11,
-                                     events=1))
+             hw.motor1, 0, 10,
+             hw.motor2, 0, 10,
+             hw.motor3, 0, 10, 11,
+             events=1))
+
 
 @pytest.mark.timeout(PLAN_TIMEOUT)
 def test_fixed_target_scan(RE, hw, sample_file):

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -200,6 +200,14 @@ def test_daq_a3scan(RE, daq, hw):
                                      hw.motor3, 0, 10, 11,
                                      events=1))
 
+@pytest.mark.timeout(PLAN_TIMEOUT)
+def test_daq_d2scan(RE, daq, hw):
+    logger.debug('test_daq_d2scan')
+    daq_test(RE, daq, nbp.daq_d2scan([hw.det],
+                                     hw.motor1, 0, 10,
+                                     hw.motor2, 0, 10, 11,
+                                     events=1))
+
 
 @pytest.mark.timeout(PLAN_TIMEOUT)
 def test_fixed_target_scan(RE, hw, sample_file):


### PR DESCRIPTION
## Description
- adds daq_d2scan, daq_anscan, daq_dnscan
- adds tests for modules

## Motivation and Context
[Jira Ticket](https://jira.slac.stanford.edu/browse/LCLSECSD-97)

## How Has This Been Tested?
Tested in hutch-python simulated mode on clone of pcds dev environment.  
Confirmed plans appear in `bp` namespace

## Where Has This Been Documented?
Docstrings have been updated.


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
