### PR TITLE
ENH: Add ELog posting callback

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
       - bluesky >=1.6.5
       - numpy
       - ophyd
+      - pandas
       - scipy
       - toolz
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 flake8
+matplotlib
 pytest
 pcdsdaq
 pcdsdevices
-matplotlib

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ flake8
 pytest
 pcdsdaq
 pcdsdevices
+matplotlib

--- a/docs/source/upcoming_release_notes/53-ELog_Post_Callback.rst
+++ b/docs/source/upcoming_release_notes/53-ELog_Post_Callback.rst
@@ -1,0 +1,24 @@
+53 ELog Post Callback
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add callback to RE for posting last input and run table to ELog.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong
+- klauer
+- zllentz

--- a/docs/source/upcoming_release_notes/53-ELog_Post_Callback.rst
+++ b/docs/source/upcoming_release_notes/53-ELog_Post_Callback.rst
@@ -20,5 +20,4 @@ Maintenance
 Contributors
 ------------
 - tangkong
-- klauer
 - zllentz

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -1,0 +1,89 @@
+"""
+Callbacks for subscription to the Bluesky ``RunEngine``
+
+This is the LCLS counterpart to `bluesky.callbacks`
+
+Callbacks in this module expect and operate on the `start`, `event`,
+`stop`, etc documents.
+"""
+
+import logging
+
+from bluesky.callbacks.core import CallbackBase, make_class_safe
+
+logger = logging.getLogger(__name__)
+
+
+@make_class_safe(logger=logger)
+class ELogPoster(CallbackBase):
+    """
+    Callback to post messages to the elog, primarily related to plan setup and
+    results. This callback relies on and must be instantiated after the
+    BestEffortCallback and HutchELog.
+
+    To subscribe:
+
+    .. code-block:: python
+
+        elogc = ELogPoster(bec, elog)
+        elogc_uid = RE.subscribe(elogc)
+
+    To enable posting for a specific run:
+
+    .. code-block:: python
+
+        RE(plan(), post=True)
+
+    Parameters
+    ----------
+    bec : BestEffortCallback
+        Instance of BestEffortCallback subscribed to the current RunEngine
+
+    elog : HutchELog
+        Instance of HutchELog connected to the desired logbook
+    """
+    def __init__(self, bec, elog):
+        self._bec = bec
+        self._elog = elog
+
+        # default to elog setting
+        self._send_post = elog.enable_run_posts
+
+        # TO-DO:
+        # - add granular switches as optional arguments
+        # - add error handling for misspelled keys
+        # - add default lists for start doc keys, elog tags?
+
+    def start(self, doc):
+        """ Post plan information on start document"""
+        if 'post' in doc.keys():
+            # Override default if key exists
+            self._send_post = doc['post']
+
+        if self._send_post:
+            run_info = str({k: doc[k] for k in ['plan_name', 'plan_args']})
+            logger.info(f"Posting run start information to elog, \
+                            experiment {self._elog.logbooks['experiment']}")
+            self._elog.post(run_info, tags=['plan_info', 'RE'])
+
+        super().start(doc)
+
+    def stop(self, doc):
+        """ Post to ELog on plan close (stop document)"""
+
+        super().stop(doc)
+
+        # need to hold onto BEC, instead of the table it holds?...
+        table = self._bec._table._rows
+
+        # Can be None of table isn't generated (ie. bp.count)
+        if table and self._send_post:
+            logger.info(f"Posting run table information to elog, \
+                            experiment {self._elog.logbooks['experiment']}")
+            self._elog.post(
+                '\n'.join(table),
+                tags=['run_table', 'RE']
+            )
+
+        # Clean up
+        self._send_post = self._elog.enable_run_posts

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -46,9 +46,6 @@ class ELogPoster(CallbackBase):
         self._bec = bec
         self._elog = elog
 
-        # default to elog setting
-        self._send_post = elog.enable_run_posts
-
         # TO-DO:
         # - add granular switches as optional arguments
         # - add error handling for misspelled keys
@@ -56,11 +53,7 @@ class ELogPoster(CallbackBase):
 
     def start(self, doc):
         """ Post plan information on start document"""
-        if 'post' in doc.keys():
-            # Override default if key exists
-            self._send_post = doc['post']
-        else:
-            self._send_post = self._elog.enable_run_posts
+        self._send_post = doc.get('post', self._elog.enable_run_posts)
 
         if self._send_post:
             run_info = str({k: doc[k] for k in ['plan_name', 'plan_args']})

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -8,7 +8,9 @@ Callbacks in this module expect and operate on the `start`, `event`,
 """
 
 import logging
+from datetime import datetime
 
+import pandas as pd
 from bluesky.callbacks.core import CallbackBase, make_class_safe
 
 logger = logging.getLogger(__name__)
@@ -42,19 +44,61 @@ class ELogPoster(CallbackBase):
     elog : HutchELog
         Instance of HutchELog connected to the desired logbook
     """
-    def __init__(self, bec, elog, ipython):
-        self._bec = bec
+    _FMTLOOKUP = {'string': '{:.5s}',
+                  'float': '{:.2f}',
+                  'number': '{:.3g}',
+                  'integer': '{:d}'}
+
+    _html_head = """<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #dddddd;
+}
+</style>
+</head>
+<body>
+"""
+
+    _html_tail = "</body> </html>"
+
+    def __init__(self, elog, ipython):
         self._elog = elog
         self._ipython = ipython
+        self._data = dict()
+        self._descriptors = set()
+        self._data_keys = []
+        self._format_info = dict()
 
         # TO-DO:
         # - add granular switches as optional arguments
         # - add error handling for misspelled keys
         # - add default lists for start doc keys, elog tags?
+        # - handling if data key collides with seq_num, time?
+        # - consider pulling precision from data
 
     def start(self, doc):
         """ Post plan information on start document"""
         self._send_post = doc.get('post', self._elog.enable_run_posts)
+
+        # Clean up before starting new run
+        self._data = dict()
+        self._descriptors = set()
+        self._data_keys = []
+        self._format_info = dict()
 
         if self._send_post:
             # Grab last ipython input
@@ -64,18 +108,59 @@ class ELogPoster(CallbackBase):
 
         super().start(doc)
 
+    def descriptor(self, doc):
+        """ Initialize table information """
+        # these always exist
+        self._data = dict(seq_num=[], time=[])
+        for k in doc['data_keys']:
+            dk_entry = doc['data_keys'][k]
+
+            if dk_entry['dtype'] not in self._FMTLOOKUP:
+                logger.warn(f'skipping {k}, format not recognized')
+                continue
+
+            self._data.update({k: []})
+            self._data_keys.append(k)
+            self._format_info.update({k: dk_entry['dtype']})
+
+        self._descriptors.add(doc['uid'])
+        # To-do: consider signals with mismatched keys
+
+    def event(self, doc):
+        if doc['descriptor'] not in self._descriptors:
+            return
+
+        self._data['seq_num'].append(doc['seq_num'])
+        self._data['time'].append(
+            str(datetime.fromtimestamp(doc['time']).time())[:-4]
+            )
+
+        # this might break for unfilled data, but do we deal with that?
+        for k in self._data_keys:
+            try:
+                dtype = self._format_info[k]
+                style = self._FMTLOOKUP[dtype]
+                self._data[k].append(style.format(doc['data'][k]))
+            except Exception as ex:
+                print(ex)
+                logger.warning(f'key: {k} not in event document')
+
+    def _create_html_table(self):
+        df = pd.DataFrame(dict(self._data))
+        return df.to_html(index=False)
+
     def stop(self, doc):
         """ Post to ELog on plan close (stop document)"""
         super().stop(doc)
-        # need to hold onto BEC, instead of the table it holds?...
-        table = self._bec._table._rows
-        # Can be None of table isn't generated (ie. bp.count)
-        if (table is not None) and self._send_post:
+
+        # if no events were generated, don't send an empty table
+        if self._data and self._send_post:
+            html_body = self._create_html_table()
+            final_message = self._html_head + html_body + self._html_tail
+
             logger.info("Posting run table information to elog")
             self._elog.post(
-                '\n'.join(table),
-                tags=['run_table', 'RE']
+                final_message,
+                tags=['run_table', 'RE'],
+                title='run_table'
             )
-
-        # Clean up
-        self._send_post = self._elog.enable_run_posts

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -115,7 +115,8 @@ tr:nth-child(even) {
         for k, dk_entry in doc['data_keys'].items():
 
             if dk_entry['dtype'] not in self._FMTLOOKUP:
-                logger.warn(f'skipping {k}, format not recognized')
+                logger.warn(f'skipping {k}, format {dk_entry["dtype"]}'
+                            'not recognized')
                 continue
 
             self._data[k] = []
@@ -142,6 +143,8 @@ tr:nth-child(even) {
                 self._data[k].append(style.format(doc['data'][k]))
             except Exception as ex:
                 logger.warning(f'Entry {k} failed with exception {ex}')
+                # Fallback to default value
+                self._data[k].append('N/A')
 
     def _create_html_table(self):
         df = pd.DataFrame(dict(self._data))

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -58,7 +58,7 @@ class ELogPoster(CallbackBase):
 
         if self._send_post:
             # Grab last ipython input
-            run_info = self._ipython.user_ns[-1]
+            run_info = self._ipython.user_ns["In"][-1]
             logger.info("Posting run start information to elog")
             self._elog.post(run_info, tags=['plan_info', 'RE'])
 

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -112,14 +112,13 @@ tr:nth-child(even) {
         """ Initialize table information """
         # these always exist
         self._data = dict(seq_num=[], time=[])
-        for k in doc['data_keys']:
-            dk_entry = doc['data_keys'][k]
+        for k, dk_entry in doc['data_keys'].items():
 
             if dk_entry['dtype'] not in self._FMTLOOKUP:
                 logger.warn(f'skipping {k}, format not recognized')
                 continue
 
-            self._data.update({k: []})
+            self._data[k] = []
             self._data_keys.append(k)
             self._format_info.update({k: dk_entry['dtype']})
 
@@ -142,7 +141,7 @@ tr:nth-child(even) {
                 style = self._FMTLOOKUP[dtype]
                 self._data[k].append(style.format(doc['data'][k]))
             except Exception as ex:
-                logger.warning(f'key: {k} not in event document')
+                logger.warning(f'Entry {k} failed with exception {ex}')
 
     def _create_html_table(self):
         df = pd.DataFrame(dict(self._data))

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -142,7 +142,6 @@ tr:nth-child(even) {
                 style = self._FMTLOOKUP[dtype]
                 self._data[k].append(style.format(doc['data'][k]))
             except Exception as ex:
-                print(ex)
                 logger.warning(f'key: {k} not in event document')
 
     def _create_html_table(self):

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -42,9 +42,10 @@ class ELogPoster(CallbackBase):
     elog : HutchELog
         Instance of HutchELog connected to the desired logbook
     """
-    def __init__(self, bec, elog):
+    def __init__(self, bec, elog, ipython):
         self._bec = bec
         self._elog = elog
+        self._ipython = ipython
 
         # TO-DO:
         # - add granular switches as optional arguments
@@ -56,7 +57,8 @@ class ELogPoster(CallbackBase):
         self._send_post = doc.get('post', self._elog.enable_run_posts)
 
         if self._send_post:
-            run_info = str({k: doc[k] for k in ['plan_name', 'plan_args']})
+            # Grab last ipython input
+            run_info = self._ipython.user_ns[-1]
             logger.info("Posting run start information to elog")
             self._elog.post(run_info, tags=['plan_info', 'RE'])
 

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -59,27 +59,24 @@ class ELogPoster(CallbackBase):
         if 'post' in doc.keys():
             # Override default if key exists
             self._send_post = doc['post']
+        else:
+            self._send_post = self._elog.enable_run_posts
 
         if self._send_post:
             run_info = str({k: doc[k] for k in ['plan_name', 'plan_args']})
-            logger.info(f"Posting run start information to elog, \
-                            experiment {self._elog.logbooks['experiment']}")
+            logger.info("Posting run start information to elog")
             self._elog.post(run_info, tags=['plan_info', 'RE'])
 
         super().start(doc)
 
     def stop(self, doc):
         """ Post to ELog on plan close (stop document)"""
-
         super().stop(doc)
-
         # need to hold onto BEC, instead of the table it holds?...
         table = self._bec._table._rows
-
         # Can be None of table isn't generated (ie. bp.count)
-        if table and self._send_post:
-            logger.info(f"Posting run table information to elog, \
-                            experiment {self._elog.logbooks['experiment']}")
+        if (table is not None) and self._send_post:
+            logger.info("Posting run table information to elog")
             self._elog.post(
                 '\n'.join(table),
                 tags=['run_table', 'RE']

--- a/nabs/tests/conftest.py
+++ b/nabs/tests/conftest.py
@@ -5,8 +5,7 @@ from bluesky import RunEngine
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
 from ophyd.pseudopos import (PseudoPositioner, PseudoSingle,
-                             pseudo_position_argument,
-                             real_position_argument)
+                             pseudo_position_argument, real_position_argument)
 from ophyd.sim import hw as sim_hw
 from pcdsdaq.daq import Daq
 from pcdsdaq.sim import set_sim_mode
@@ -51,6 +50,20 @@ def daq(RE):
     set_sim_mode(True)
     yield Daq(RE=RE, hutch_name='tst')
     set_sim_mode(False)
+
+
+@pytest.fixture(scope='function')
+def elog():
+    class MockELog:
+
+        def __init__(self, *args, **kwargs):
+            self.posts = list()
+            self.enable_run_posts = True
+
+        def post(self, *args, **kwargs):
+            self.posts.append((args, kwargs))
+
+    return MockELog('TST')
 
 
 @pytest.fixture(scope='function')

--- a/nabs/tests/conftest.py
+++ b/nabs/tests/conftest.py
@@ -55,7 +55,6 @@ def daq(RE):
 @pytest.fixture(scope='function')
 def elog():
     class MockELog:
-
         def __init__(self, *args, **kwargs):
             self.posts = list()
             self.enable_run_posts = True
@@ -64,6 +63,15 @@ def elog():
             self.posts.append((args, kwargs))
 
     return MockELog('TST')
+
+
+@pytest.fixture(scope='function')
+def ipython():
+    class MockIPython:
+        def __init__(self, *args, **kwargs):
+            self.user_ns = dict(In=[""])
+
+    return MockIPython()
 
 
 @pytest.fixture(scope='function')

--- a/nabs/tests/test_callbacks.py
+++ b/nabs/tests/test_callbacks.py
@@ -19,14 +19,17 @@ def _compare_tables(fout, known_table):
             assert ln[25:] == kn[25:]
 
 
-def test_elog_callback(RE, hw, elog):
+def test_elog_callback(RE, hw, elog, ipython):
     bec = BestEffortCallback()
-    elogc = ELogPoster(bec, elog)
+    elogc = ELogPoster(bec, elog, ipython)
     elogc.enable_run_posts = True
 
     bec_uid = RE.subscribe(bec)
     elog_uid = RE.subscribe(elogc)
 
+    ipython.user_ns["In"].append(
+        "RE(bp.scan([hw.det], hw.motor, 0, 1, num=10))"
+        )
     RE(bp.scan([hw.det], hw.motor, 0, 1, num=10))
 
     assert len(elog.posts) == 2  # start and table posts

--- a/nabs/tests/test_callbacks.py
+++ b/nabs/tests/test_callbacks.py
@@ -1,30 +1,12 @@
 import bluesky.plans as bp
-from bluesky.callbacks.best_effort import BestEffortCallback
 
 from ..callbacks import ELogPoster
 
 
-def _compare_tables(fout, known_table):
-    # Stolen shamelessly from bluesky tests
-    for ln, kn in zip(fout.split('\n'), known_table.split('\n')):
-        # this is to strip the `\n` from the print output
-        ln = ln.rstrip()
-        if ln[0] == '+':
-            # test the full line on the divider lines
-            assert ln == kn
-        else:
-            # skip the 'time' column on data rows
-            # this is easier than faking up times in the scan!
-            assert ln[:13] == kn[:13]
-            assert ln[25:] == kn[25:]
-
-
 def test_elog_callback(RE, hw, elog, ipython):
-    bec = BestEffortCallback()
-    elogc = ELogPoster(bec, elog, ipython)
+    elogc = ELogPoster(elog, ipython)
     elogc.enable_run_posts = True
 
-    bec_uid = RE.subscribe(bec)
     elog_uid = RE.subscribe(elogc)
 
     ipython.user_ns["In"].append(
@@ -35,29 +17,32 @@ def test_elog_callback(RE, hw, elog, ipython):
     assert len(elog.posts) == 2  # start and table posts
     assert 'plan_info' in elog.posts[0][1]['tags']
     assert 'RE' in elog.posts[0][1]['tags']
-    KNOWN_TABLE = """+-----------+------------+------------+------------+
-|   seq_num |       time |      motor |        det |
-+-----------+------------+------------+------------+
-|         1 | 12:50:56.8 |      0.000 |      1.000 |
-|         2 | 12:50:56.8 |      0.111 |      0.994 |
-|         3 | 12:50:56.9 |      0.222 |      0.976 |
-|         4 | 12:50:56.9 |      0.333 |      0.946 |
-|         5 | 12:50:56.9 |      0.444 |      0.906 |
-|         6 | 12:50:57.0 |      0.556 |      0.857 |
-|         7 | 12:50:57.0 |      0.667 |      0.801 |
-|         8 | 12:50:57.0 |      0.778 |      0.739 |
-|         9 | 12:50:57.1 |      0.889 |      0.674 |
-|        10 | 12:50:57.1 |      1.000 |      0.607 |
-+-----------+------------+------------+------------+"""
-    _compare_tables(elog.posts[1][0][0], KNOWN_TABLE)
 
+    ipython.user_ns["In"].append(
+        "RE(bp.scan([hw.det], hw.motor, 0, 1, num=10), post=False)"
+        )
     RE(bp.scan([hw.det], hw.motor, 0, 1, num=10), post=False)
     assert len(elog.posts) == 2  # confirm no new entries
 
     elog.enable_run_posts = False
+    ipython.user_ns["In"].append(
+        "RE(bp.scan([hw.det], hw.motor, 0, 1, num=10))"
+        )
     RE(bp.scan([hw.det], hw.motor, 0, 1, num=10))
     assert len(elog.posts) == 2  # confirm no new entries
 
+    # Test override of elog default
+    last_cmd = "RE(bp.scan([hw.det], hw.motor, 10, 0, num=10), post=True)"
+    ipython.user_ns["In"].append(last_cmd)
+    RE(bp.scan([hw.det], hw.motor, 10, 0, num=10), post=True)
+    assert len(elog.posts) == 4
+    assert elog.posts[-2][0][0] == last_cmd
+
+    # test behavior when no table is generated
+    last_cmd = "RE(bp.count([]), post=True)"
+    ipython.user_ns["In"].append(last_cmd)
+    RE(bp.count([]), post=True)
+    assert len(elog.posts) == 5  # empty table should not be posted
+
     # cleanup
-    RE.unsubscribe(bec_uid)
     RE.unsubscribe(elog_uid)

--- a/nabs/tests/test_callbacks.py
+++ b/nabs/tests/test_callbacks.py
@@ -1,0 +1,60 @@
+import bluesky.plans as bp
+from bluesky.callbacks.best_effort import BestEffortCallback
+
+from ..callbacks import ELogPoster
+
+
+def _compare_tables(fout, known_table):
+    # Stolen shamelessly from bluesky tests
+    for ln, kn in zip(fout.split('\n'), known_table.split('\n')):
+        # this is to strip the `\n` from the print output
+        ln = ln.rstrip()
+        if ln[0] == '+':
+            # test the full line on the divider lines
+            assert ln == kn
+        else:
+            # skip the 'time' column on data rows
+            # this is easier than faking up times in the scan!
+            assert ln[:13] == kn[:13]
+            assert ln[25:] == kn[25:]
+
+
+def test_elog_callback(RE, hw, elog):
+    bec = BestEffortCallback()
+    elogc = ELogPoster(bec, elog)
+    elogc.enable_run_posts = True
+
+    bec_uid = RE.subscribe(bec)
+    elog_uid = RE.subscribe(elogc)
+
+    RE(bp.scan([hw.det], hw.motor, 0, 1, num=10))
+
+    assert len(elog.posts) == 2  # start and table posts
+    assert 'plan_info' in elog.posts[0][1]['tags']
+    assert 'RE' in elog.posts[0][1]['tags']
+    KNOWN_TABLE = """+-----------+------------+------------+------------+
+|   seq_num |       time |      motor |        det |
++-----------+------------+------------+------------+
+|         1 | 12:50:56.8 |      0.000 |      1.000 |
+|         2 | 12:50:56.8 |      0.111 |      0.994 |
+|         3 | 12:50:56.9 |      0.222 |      0.976 |
+|         4 | 12:50:56.9 |      0.333 |      0.946 |
+|         5 | 12:50:56.9 |      0.444 |      0.906 |
+|         6 | 12:50:57.0 |      0.556 |      0.857 |
+|         7 | 12:50:57.0 |      0.667 |      0.801 |
+|         8 | 12:50:57.0 |      0.778 |      0.739 |
+|         9 | 12:50:57.1 |      0.889 |      0.674 |
+|        10 | 12:50:57.1 |      1.000 |      0.607 |
++-----------+------------+------------+------------+"""
+    _compare_tables(elog.posts[1][0][0], KNOWN_TABLE)
+
+    RE(bp.scan([hw.det], hw.motor, 0, 1, num=10), post=False)
+    assert len(elog.posts) == 2  # confirm no new entries
+
+    elog.enable_run_posts = False
+    RE(bp.scan([hw.det], hw.motor, 0, 1, num=10))
+    assert len(elog.posts) == 2  # confirm no new entries
+
+    # cleanup
+    RE.unsubscribe(bec_uid)
+    RE.unsubscribe(elog_uid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bluesky>=1.6.5
 numpy
 ophyd
+pandas
 scipy
 toolz


### PR DESCRIPTION
## Description
Adds a callback that posts bluesky run information to the ELog automatically.  Currently posts last ipython input at run start, and a copy of the run table as html at run stop

## Motivation and Context
[JIRA ticket](https://jira.slac.stanford.edu/browse/LCLSECSD-324)

## How Has This Been Tested?
Interactively, with new test added to test suite
Test posts to [devlgbk](https://pswww.slac.stanford.edu/devlgbk/lgbk/tsdx00117/#eLog) 
pcds-5.2.0, pcds-5.2.1

<img width="1170" alt="Screen Shot 2022-02-16 at 2 08 29 PM" src="https://user-images.githubusercontent.com/35379409/154546920-447d98e0-6e06-4b59-ab5e-0e8a7a3dcf69.png">

## Where Has This Been Documented?
Some docstrings, including example usage.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
