### PR TITLE
ENH: Elog poster for ophyd objects and lists thereof

### DIFF
--- a/docs/source/upcoming_release_notes/55-elog_ophyd_poster.rst
+++ b/docs/source/upcoming_release_notes/55-elog_ophyd_poster.rst
@@ -1,0 +1,22 @@
+55 elog ophyd poster
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Add function for posting ophyd object status (and lists of objects) to ELog as html.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/nabs/_html.py
+++ b/nabs/_html.py
@@ -1,0 +1,108 @@
+"""
+html templates for use in elog post formatting
+"""
+
+collapse_list_head = """<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+.collapsible {
+  background-color: #777;
+  color: white;
+  padding: 10px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+}
+
+.collapsible:hover {
+  background-color: #555;
+}
+
+.collapsible:after {
+  content: '+';
+  color: white;
+  font-weight: bold;
+  float: right;
+  margin-left: 5px;
+}
+
+.active:after {
+  content: "-";
+}
+
+.content {
+  min-width: 100px;
+  overflow-x: auto;
+}
+
+.parent,
+.child {
+  display: none;
+  margin-left: 20px;
+}
+
+.parent.show,
+.child.show {
+  display: block;
+}
+</style>
+</head>
+<body>
+"""
+
+collapse_list_tail = """<script>
+// manage +/- toggle
+var coll = document.getElementsByClassName("collapsible");
+var i;
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", function() {
+    this.classList.toggle("active");
+    var content = this.nextElementSibling;
+  });
+}
+
+// manage show/hide behavior
+var allCollapsibles = document.querySelectorAll('.collapsible');
+allCollapsibles.forEach( item => {
+  item.addEventListener("click", function() {
+     if(this.nextElementSibling.classList.contains('show')) {
+       this.nextElementSibling.classList.remove('show')
+     } else {
+       this.nextElementSibling.classList.add('show')
+     }
+  });
+});
+</script>
+
+</body>
+</html>"""
+
+run_table_head = """<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #dddddd;
+}
+</style>
+</head>
+<body>
+"""
+
+run_table_tail = """</body> </html>"""

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -13,6 +13,8 @@ from datetime import datetime
 import pandas as pd
 from bluesky.callbacks.core import CallbackBase, make_class_safe
 
+from ._html import run_table_head, run_table_tail
+
 logger = logging.getLogger(__name__)
 
 
@@ -27,7 +29,7 @@ class ELogPoster(CallbackBase):
 
     .. code-block:: python
 
-        elogc = ELogPoster(bec, elog)
+        elogc = ELogPoster(elog, IPython.get_ipython())
         elogc_uid = RE.subscribe(elogc)
 
     To enable posting for a specific run:
@@ -49,31 +51,9 @@ class ELogPoster(CallbackBase):
                   'number': '{:.3g}',
                   'integer': '{:d}'}
 
-    _html_head = """<!DOCTYPE html>
-<html>
-<head>
-<style>
-table {
-  font-family: arial, sans-serif;
-  border-collapse: collapse;
-  width: 100%;
-}
+    _html_head = run_table_head
 
-td, th {
-  border: 1px solid #dddddd;
-  text-align: left;
-  padding: 8px;
-}
-
-tr:nth-child(even) {
-  background-color: #dddddd;
-}
-</style>
-</head>
-<body>
-"""
-
-    _html_tail = "</body> </html>"
+    _html_tail = run_table_tail
 
     def __init__(self, elog, ipython):
         self._elog = elog

--- a/nabs/tests/test_utils.py
+++ b/nabs/tests/test_utils.py
@@ -1,0 +1,48 @@
+from ophyd.device import Component as Cpt
+from ophyd.device import Device
+from pcdsdevices.device import GroupDevice
+
+from nabs.utils import post_ophyds_to_elog
+
+
+class StatusDevice(Device):
+    """ simulate a device with a status method """
+    def status(self):
+        return self.name
+
+
+class BasicGroup(StatusDevice, GroupDevice):
+    one = Cpt(StatusDevice, ':BASIC')
+    two = Cpt(StatusDevice, ':COMPLEX')
+
+
+class SomeDevice(StatusDevice):
+    some = Cpt(StatusDevice, ':SOME')
+    where = Cpt(StatusDevice, ':WHERE')
+
+
+def test_ophyd_to_elog(elog):
+    # make some devices
+
+    group = BasicGroup('GROUP', name='group')
+    some = SomeDevice('SOME', name='some')
+
+    post_ophyds_to_elog(elog, [group, some])
+    assert len(elog.posts) == 1
+    # count number of content entries
+    assert elog.posts[-1][0][0].count('<pre>') == 2
+
+    post_ophyds_to_elog(elog, [group.one, some.some])
+    assert len(elog.posts) == 1  # no children allowed by default
+
+    post_ophyds_to_elog(elog, [[group, some], group.one, some.some],
+                        allow_child=True)
+    assert len(elog.posts) == 2
+    assert elog.posts[-1][0][0].count('<pre>') == 4
+    # two list levels
+    assert elog.posts[-1][0][0].count('expand me') == 2
+
+    # half-hearted html validation
+    for post in elog.posts:
+        for tag in ['pre', 'div', 'button']:
+            assert post[0][0].count('<'+tag) == post[0][0].count('</'+tag)

--- a/nabs/tests/test_utils.py
+++ b/nabs/tests/test_utils.py
@@ -27,16 +27,16 @@ def test_ophyd_to_elog(elog):
     group = BasicGroup('GROUP', name='group')
     some = SomeDevice('SOME', name='some')
 
-    post_ophyds_to_elog(elog, [group, some])
+    post_ophyds_to_elog([group, some], hutch_elog=elog)
     assert len(elog.posts) == 1
     # count number of content entries
     assert elog.posts[-1][0][0].count('<pre>') == 2
 
-    post_ophyds_to_elog(elog, [group.one, some.some])
+    post_ophyds_to_elog([group.one, some.some], hutch_elog=elog)
     assert len(elog.posts) == 1  # no children allowed by default
 
-    post_ophyds_to_elog(elog, [[group, some], group.one, some.some],
-                        allow_child=True)
+    post_ophyds_to_elog([[group, some], group.one, some.some],
+                        allow_child=True, hutch_elog=elog)
     assert len(elog.posts) == 2
     assert elog.posts[-1][0][0].count('<pre>') == 4
     # two list levels

--- a/nabs/tests/test_utils.py
+++ b/nabs/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_ophyd_to_elog(elog):
     assert len(elog.posts) == 2
     assert elog.posts[-1][0][0].count('<pre>') == 4
     # two list levels
-    assert elog.posts[-1][0][0].count('expand me') == 2
+    assert elog.posts[-1][0][0].count("class='parent'") == 2
 
     # half-hearted html validation
     for post in elog.posts:

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -144,6 +144,10 @@ def format_ophyds_to_html(obj, allow_child=False):
         for o in obj:
             content += format_ophyds_to_html(o, allow_child=allow_child)
 
+        # Don't return wrapping if there's no content
+        if content == "":
+            return content
+
         # HelpfulNamespaces tend to lack names, maybe they won't some day
         parent_name = getattr(obj, '__name__', 'expand me')
 
@@ -158,7 +162,10 @@ def format_ophyds_to_html(obj, allow_child=False):
         return out
 
     # check if parent level ophyd object
-    elif hasattr(obj, 'status') and (obj.parent is None or allow_child):
+    elif (hasattr(obj, 'status') and
+            ((getattr(obj, 'parent', None) is None and
+              getattr(obj, 'biological_parent', None) is None) or
+             allow_child)):
         content = ""
         try:
             content = (
@@ -205,6 +212,10 @@ def post_ophyds_to_elog(elog, objs, allow_child=False):
 
     """
     post = format_ophyds_to_html(objs, allow_child=allow_child)
+
+    if post == "":
+        logger.info("No valid devices found, no post submitted")
+        return
 
     # wrap post in head and tail
     final_post = collapse_list_head + post + collapse_list_tail

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -153,7 +153,10 @@ def format_ophyds_to_html(obj, allow_child=False):
             return content
 
         # HelpfulNamespaces tend to lack names, maybe they won't some day
-        parent_name = getattr(obj, '__name__', 'expand me')
+        parent_default = ('Ophyd status: ' +
+                          ', '.join('[...]' if isinstance(o, Iterable)
+                                    else o.name for o in obj))
+        parent_name = getattr(obj, '__name__', parent_default[:60] + ' ...')
 
         # Wrap in a parent div
         out = (
@@ -166,7 +169,7 @@ def format_ophyds_to_html(obj, allow_child=False):
         return out
 
     # check if parent level ophyd object
-    elif (hasattr(obj, 'status') and
+    elif (callable(getattr(obj, 'status', None)) and
             ((getattr(obj, 'parent', None) is None and
               getattr(obj, 'biological_parent', None) is None) or
              allow_child)):

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -133,6 +133,10 @@ def format_ophyds_to_html(obj, allow_child=False):
     obj : ophyd object or Iterable of ophyd objects
         Objects to format into html
 
+    allow_child : bool, optional
+        Whether or not to post child devices to the elog.  Defaults to False,
+        to keep long lists of devices concise
+
     Returns
     -------
     out : string
@@ -209,6 +213,10 @@ def post_ophyds_to_elog(elog, objs, allow_child=False):
 
     objs : ophyd object or Iterable of ophyd objects
         Objects to format and post
+
+    allow_child : bool, optional
+        Whether or not to post child devices to the elog.  Defaults to False,
+        to keep long lists of devices concise
 
     """
     post = format_ophyds_to_html(objs, allow_child=allow_child)

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -222,7 +222,7 @@ def post_ophyds_to_elog(objs, allow_child=False, hutch_elog=None):
         ELog instance to post to.  If not provided, will attempt to grab
         primary registered ELog instance
     """
-    if hutch_elog is not None:
+    if hutch_elog is None:
         try:
             from elog.utils import get_primary_elog
             hutch_elog = get_primary_elog()

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -227,7 +227,8 @@ def post_ophyds_to_elog(objs, allow_child=False, hutch_elog=None):
             from elog.utils import get_primary_elog
             hutch_elog = get_primary_elog()
         except ValueError:
-            logger.debug('elog module exists, but no elog registered')
+            logger.info('elog module exists, but no elog registered')
+            return
     else:
         logger.info('Posting to provided elog')
 

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -166,10 +166,13 @@ def format_ophyds_to_html(obj, allow_child=False):
                 f"<div class='child content'><pre>{obj.status()}</pre></div>"
             )
         except Exception as ex:
-            print(f'skipped {str(obj)}, due to Exception: {ex}')
-            # logger.info(f'skipped {str(obj)}, due to Exception: {ex}')
+            logger.info(f'skipped {str(obj)}, due to Exception: {ex}')
 
         return content
+
+    # fallback base case (if ignoring obj)
+    else:
+        return ""
 
 
 def post_ophyds_to_elog(elog, objs, allow_child=False):
@@ -201,7 +204,7 @@ def post_ophyds_to_elog(elog, objs, allow_child=False):
         Objects to format and post
 
     """
-    post = format_ophyds_to_html(objs, allow_child)
+    post = format_ophyds_to_html(objs, allow_child=allow_child)
 
     # wrap post in head and tail
     final_post = collapse_list_head + post + collapse_list_tail


### PR DESCRIPTION
## Description
Added a function (and helper function) for gathering up ophyd objects and posting them to the elog.  
Recursively walks through an iterable of devices and formats their `.status()` output into collapsible blocks.  

## Motivation and Context
[Jira ticket](https://jira.slac.stanford.edu/browse/LCLSPC-124)

Hopefully this will provide another way for scientists to log their beamline state.  

With the new `biological_parents` attribute of `GroupDevices`, we can post entire namespaces without cluttering the post with child devices

## How Has This Been Tested?
Interactively, sample posts using devices in xcs hutch python, a few tests have been added to `test_utils.py`
pcds-5.3.0

## Where Has This Been Documented?
Docstrings, which have some example code

<img width="852" alt="image" src="https://user-images.githubusercontent.com/35379409/156434618-afec1d67-86bd-47d7-9032-d69dd6ed670e.png">

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
