### PR TITLE
ENH: Decorator to interpret floats as step sizes and integers as number of steps

### DIFF
--- a/docs/source/upcoming_release_notes/56-step_size_decorator.rst
+++ b/docs/source/upcoming_release_notes/56-step_size_decorator.rst
@@ -1,0 +1,22 @@
+56 step size decorator
+#################
+
+API Changes
+-----------
+- 1-Dimensional scans now accept floats in the 'num' argument position and interprets it as a step size.
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -454,6 +454,7 @@ def daq_list_scan(*args, per_step=None, md=None):
 
 @bpp.reset_positions_decorator()
 @nbpp.daq_step_scan_decorator
+@nbpp.step_size_decorator
 def daq_ascan(detectors, motor, start, end, nsteps):
     """
     One-dimensional daq scan with absolute positions.
@@ -507,6 +508,7 @@ def daq_ascan(detectors, motor, start, end, nsteps):
 @bpp.reset_positions_decorator()
 @bpp.relative_set_decorator()
 @nbpp.daq_step_scan_decorator
+@nbpp.step_size_decorator
 def daq_dscan(detectors, motor, start, end, nsteps):
     """
     One-dimensional daq scan with relative (delta) positions.

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -455,7 +455,7 @@ def daq_list_scan(*args, per_step=None, md=None):
 @bpp.reset_positions_decorator()
 @nbpp.daq_step_scan_decorator
 @nbpp.step_size_decorator
-def daq_ascan(detectors, motor, start, end, nsteps):
+def daq_ascan(detectors, motor, start, end, n):
     """
     One-dimensional daq scan with absolute positions.
 
@@ -477,8 +477,9 @@ def daq_ascan(detectors, motor, start, end, nsteps):
     end : int or float
         The last point in the scan.
 
-    nsteps : int
-        The number of points in the scan.
+    n : int or float
+        if int, the number of points in the scan.
+        if float, step size
 
     events : int, optional
         Number of events to take at each step. If omitted, uses the
@@ -502,14 +503,14 @@ def daq_ascan(detectors, motor, start, end, nsteps):
     :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
     """
 
-    yield from bp.scan(detectors, motor, start, end, nsteps)
+    yield from bp.scan(detectors, motor, start, end, n)
 
 
 @bpp.reset_positions_decorator()
 @bpp.relative_set_decorator()
 @nbpp.daq_step_scan_decorator
 @nbpp.step_size_decorator
-def daq_dscan(detectors, motor, start, end, nsteps):
+def daq_dscan(detectors, motor, start, end, n):
     """
     One-dimensional daq scan with relative (delta) positions.
 
@@ -531,8 +532,9 @@ def daq_dscan(detectors, motor, start, end, nsteps):
     end : int or float
         The last point in the scan, relative to the current position.
 
-    nsteps : int
-        The number of points in the scan.
+    n : int or float
+        if int, the number of points in the scan.
+        if float, step size
 
     events : int, optional
         Number of events to take at each step. If omitted, uses the
@@ -556,7 +558,7 @@ def daq_dscan(detectors, motor, start, end, nsteps):
     :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
     """
 
-    yield from bp.scan(detectors, motor, start, end, nsteps)
+    yield from bp.scan(detectors, motor, start, end, n)
 
 
 @bpp.reset_positions_decorator()

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -345,6 +345,8 @@ def step_size_decorator(plan):
         elif type(n) is float:
             # interpret as step size
             start, stop = args[2], args[3]
+            # correct step size sign
+            n = np.sign(stop - start) * np.abs(n)
             if np.abs(n) > np.abs(stop-start):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -341,23 +341,19 @@ def step_size_decorator(plan):
 
         if type(n) is int:
             # interpret as number of steps (default)
-            yield from plan(*args[:4], n, **kwargs)
-
+            yield from plan(*args, **kwargs)
         elif type(n) is float:
             # interpret as step size
             mmin, mmax = args[2], args[3]
-
             if n > (mmax-mmin):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "
                                  f"{mmax-mmin}")
-
             step_list = list(np.arange(mmin, mmax, n))
             # new endpoint needed, for cases where
             # (range % step_size) != 0 or to include endpoint
             if np.isclose(step_list[-1] + n, mmax):
                 step_list.append(step_list[-1] + n)
-
             n_steps = len(step_list)
 
             yield from plan(*args[:3], step_list[-1], n_steps,

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -332,10 +332,10 @@ def step_size_decorator(plan):
             # do not support num kwarg
             n = kwargs.pop('num')
         else:
-            # assumes (det_list, motor, mmin, mmax, num)
+            # assumes (det_list, motor, start, stop, num)
             n = args[-1]
 
-        if type(n) not in [int, float]:
+        if not isinstance(n, (int, float)):
             raise TypeError("Step size / number of steps is "
                             "neither float nor integer")
 
@@ -344,15 +344,19 @@ def step_size_decorator(plan):
             yield from plan(*args, **kwargs)
         elif type(n) is float:
             # interpret as step size
-            mmin, mmax = args[2], args[3]
-            if n > (mmax-mmin):
+            start, stop = args[2], args[3]
+            if np.abs(n) > np.abs(stop-start):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "
-                                 f"{mmax-mmin}")
-            step_list = list(np.arange(mmin, mmax, n))
+                                 f"{np.abs(stop-start)}")
+            step_list = list(np.arange(start, stop, n))
+            if len(step_list) == 0:
+                raise ValueError("Number of steps is 0 with the "
+                                 "provided range and step size.")
+
             # new endpoint needed, for cases where
             # (range % step_size) != 0 or to include endpoint
-            if np.isclose(step_list[-1] + n, mmax):
+            if np.isclose(step_list[-1] + n, stop):
                 step_list.append(step_list[-1] + n)
             n_steps = len(step_list)
 

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -344,14 +344,12 @@ def step_size_decorator(plan):
             # interpret as number of steps (default)
             result = yield from plan(*args, **kwargs)
         elif isinstance(n, float):
-            # interpret as step size
-            start, stop = args[2], args[3]
             # correct step size sign
             n = np.sign(stop - start) * np.abs(n)
-            if np.abs(n) > np.abs(stop-start):
+            if np.abs(n) > np.abs(stop - start):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "
-                                 f"{np.abs(stop-start)}.")
+                                 f"{np.abs(stop - start)}.")
             step_list = list(np.arange(start, stop, n))
             if len(step_list) == 0:
                 raise ValueError("Number of steps is 0 with the "

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -336,30 +336,26 @@ def step_size_decorator(plan):
             # assumes (det_list, motor, start, stop, num)
             det_list, motor, start, stop, n = args
 
-        if not isinstance(n, (numbers.Integral, float)):
+        if not isinstance(n, (numbers.Integral, numbers.Real)):
             raise TypeError("Step size / number of steps is "
                             "neither float nor integer.")
 
         if isinstance(n, numbers.Integral):
             # interpret as number of steps (default)
             result = yield from plan(*args, **kwargs)
-        elif isinstance(n, float):
+        elif isinstance(n, numbers.Real):
             # correct step size sign
             n = np.sign(stop - start) * np.abs(n)
             if np.abs(n) > np.abs(stop - start):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "
                                  f"{np.abs(stop - start)}.")
-            step_list = list(np.arange(start, stop, n))
-            if len(step_list) == 0:
+            step_list = utils.orange(start, stop, n)
+            n_steps = len(step_list)
+
+            if n_steps == 0:
                 raise ValueError("Number of steps is 0 with the "
                                  "provided range and step size.")
-
-            # new endpoint needed, for cases where
-            # (range % step_size) != 0 or to include endpoint
-            if np.isclose(step_list[-1] + n, stop):
-                step_list.append(step_list[-1] + n)
-            n_steps = len(step_list)
 
             result = yield from plan(det_list, motor, start,
                                      step_list[-1], n_steps,

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -398,7 +398,7 @@ def test_daq_fixed_target_multi_scan(RE, daq, hw, sample_file):
      (-5, 5, 11, 33),    # expect 3 reads / point (det, motor, daq)
      (-5, 5, float(1.), 33),    # step size, include endpoint
      (-1, 1, np.float128(0.2), 33),   # step size, end point not close
-     (1, -1, np.float16(-0.4), 18),  # positive to negative direction
+     (1, -1, -0.4, 18),  # positive to negative direction
      (1, -1, np.float64(0.4), 18),   # ignore step sign
      (-1, 0, np.float32(0.1), 33),  # close to 0, end near start
     ]

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -10,6 +10,7 @@ from pcdsdevices.pseudopos import DelayBase
 from pcdsdevices.sim import FastMotor
 
 import nabs.plans as nbp
+from nabs.utils import orange
 
 PLAN_TIMEOUT = 60
 logger = logging.getLogger(__name__)
@@ -388,19 +389,6 @@ def test_daq_fixed_target_multi_scan(RE, daq, hw, sample_file):
     assert len(reads) == 24
     RE(msgs)
     summarize_plan(msgs)
-
-
-def orange(start, stop, num):
-    """ get scan points """
-    if type(num) is int:
-        ex_moves = list(np.linspace(start, stop, num))
-    elif type(num) is float:
-        num = np.sign(stop-start) * np.abs(num)
-        ex_moves = list(np.arange(start, stop, num))
-        if np.isclose(ex_moves[-1] + num, stop):
-            ex_moves.append(ex_moves[-1] + num)
-
-    return ex_moves
 
 
 @pytest.mark.timeout(PLAN_TIMEOUT)

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -395,6 +395,7 @@ def orange(start, stop, num):
     if type(num) is int:
         ex_moves = list(np.linspace(start, stop, num))
     elif type(num) is float:
+        num = np.sign(stop-start) * np.abs(num)
         ex_moves = list(np.arange(start, stop, num))
         if np.isclose(ex_moves[-1] + num, stop):
             ex_moves.append(ex_moves[-1] + num)
@@ -410,6 +411,7 @@ def orange(start, stop, num):
      (-5, 5, 2., 18),    # step size, include endpoint
      (-1, 1, 0.3, 21),   # step size, end point not close
      (1, -1, -0.4, 18),  # positive to negative direction
+     (1, -1, 0.4, 18),   # ignore sign of step size
     ]
 )
 def test_daq_step_size(daq, hw, start, stop, num, n_reads):
@@ -452,7 +454,3 @@ def test_bad_step_size(RE, hw):
     with pytest.raises(ValueError):
         # step size bigger than range
         RE(nbp.daq_ascan([hw.det], hw.motor1, 0, 1, 20., events=1))
-
-    with pytest.raises(ValueError):
-        # bad step direction
-        RE(nbp.daq_ascan([hw.det], hw.motor1, 0, 1, -.4, events=1))

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -390,11 +390,23 @@ def test_daq_fixed_target_multi_scan(RE, daq, hw, sample_file):
     summarize_plan(msgs)
 
 
+def orange(mmin, mmax, num):
+    """ get scan points """
+    if type(num) is int:
+        ex_moves = list(np.linspace(mmin, mmax, num))
+    elif type(num) is float:
+        ex_moves = list(np.arange(mmin, mmax, num))
+        if np.isclose(ex_moves[-1] + num, mmax):
+            ex_moves.append(ex_moves[-1] + num)
+
+    return ex_moves
+
+
 @pytest.mark.timeout(PLAN_TIMEOUT)
 @pytest.mark.parametrize(
     'mmin, mmax, num, n_reads',
     [
-     (-5, 5, 11, 33),
+     (-5, 5, 11, 33),   # expect 3 reads / point (det, motor, daq)
      (-5, 5, 2., 18),   # step size, include endpoint
      (-1, 1, 0.3, 21),  # step size, end point not close
     ]
@@ -405,15 +417,11 @@ def test_daq_step_size(daq, hw, mmin, mmax, num, n_reads):
     hw.motor1.set(x_start)
     msgs = list(nbp.daq_ascan([hw.det], hw.motor1,
                               mmin, mmax, num, events=1))
-    if type(num) is int:
-        a_expected_moves = list(np.linspace(mmin, mmax, num))
-    elif type(num) is float:
-        a_expected_moves = list(np.arange(mmin, mmax, num))
-        if np.isclose(a_expected_moves[-1] + num, mmax):
-            a_expected_moves.append(a_expected_moves[-1] + num)
 
     a_moves = [msg.args[0] for msg in msgs if msg.command == 'set']
     reads = [msg for msg in msgs if msg.command == 'read']
+
+    a_expected_moves = orange(mmin, mmax, num)
 
     assert np.isclose(a_moves, a_expected_moves + [x_start]).all()
     assert len(reads) == n_reads
@@ -422,14 +430,10 @@ def test_daq_step_size(daq, hw, mmin, mmax, num, n_reads):
     hw.motor1.set(x_start)
     msgs = list(nbp.daq_dscan([hw.det], hw.motor1,
                               mmin, mmax, num, events=1))
-    if type(num) is int:
-        d_expected_moves = list(np.linspace(mmin + x_start,
-                                            mmax + x_start, num))
-    elif type(num) is float:
-        d_expected_moves = list(np.arange(mmin + x_start,
-                                          mmax + x_start, num))
-        if np.isclose(d_expected_moves[-1] + num, mmax + x_start):
-            d_expected_moves.append(d_expected_moves[-1] + num)
+
+    d_min = mmin + x_start
+    d_max = mmax + x_start
+    d_expected_moves = orange(d_min, d_max, num)
 
     d_moves = [msg.args[0] for msg in msgs if msg.command == 'set']
     reads = [msg for msg in msgs if msg.command == 'read']

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import numbers
 from typing import Any, Callable, Dict, Union
 
 import numpy as np
@@ -113,7 +114,7 @@ def add_named_kwargs_to_signature(
     return sig.replace(parameters=start_params + wrapper_params + end_params)
 
 
-def orange(start, stop, num):
+def orange(start, stop, num, rtol=1.e-5, atol=1.e-7):
     """
     Get scan points based on the type of `num`.  If `num` is an
     integer, interpret as the number of points in a scan.  If `num`
@@ -138,12 +139,13 @@ def orange(start, stop, num):
     list
         a list of scan points
     """
-    if type(num) is int:
+    moves = []
+    if isinstance(num, numbers.Integral):
         moves = list(np.linspace(start, stop, num))
-    elif type(num) is float:
+    elif isinstance(num, numbers.Real):
         num = np.sign(stop - start) * np.abs(num)
         moves = list(np.arange(start, stop, num))
-        if np.isclose(moves[-1] + num, stop):
+        if np.isclose(moves[-1] + num, stop, rtol=rtol, atol=atol):
             moves.append(moves[-1] + num)
 
     return moves

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -129,7 +129,7 @@ def orange(start, stop, num):
     end : int or float
         The last point in the scan
 
-    n : int or float
+    num : int or float
         if int, the number of points in the scan.
         if float, step size
 
@@ -141,7 +141,7 @@ def orange(start, stop, num):
     if type(num) is int:
         moves = list(np.linspace(start, stop, num))
     elif type(num) is float:
-        num = np.sign(stop-start) * np.abs(num)
+        num = np.sign(stop - start) * np.abs(num)
         moves = list(np.arange(start, stop, num))
         if np.isclose(moves[-1] + num, stop):
             moves.append(moves[-1] + num)

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -144,8 +144,6 @@ def orange(start, stop, num, rtol=1.e-5, atol=1.e-7):
         moves = list(np.linspace(start, stop, num))
     elif isinstance(num, numbers.Real):
         num = np.sign(stop - start) * np.abs(num)
-        moves = list(np.arange(start, stop, num))
-        if np.isclose(moves[-1] + num, stop, rtol=rtol, atol=atol):
-            moves.append(moves[-1] + num)
+        moves = list(np.arange(start, stop + num, num))
 
     return moves

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Any, Callable, Dict, Union
 
+import numpy as np
 from ophyd.signal import DerivedSignal, SignalRO
 
 
@@ -110,3 +111,39 @@ def add_named_kwargs_to_signature(
     )
 
     return sig.replace(parameters=start_params + wrapper_params + end_params)
+
+
+def orange(start, stop, num):
+    """
+    Get scan points based on the type of `num`.  If `num` is an
+    integer, interpret as the number of points in a scan.  If `num`
+    is a float, interpret it as a step size.
+
+    Modified to include end points.
+
+    Parameters
+    ----------
+    start : int or float
+        The first point in the scan
+
+    end : int or float
+        The last point in the scan
+
+    n : int or float
+        if int, the number of points in the scan.
+        if float, step size
+
+    Returns
+    -------
+    list
+        a list of scan points
+    """
+    if type(num) is int:
+        moves = list(np.linspace(start, stop, num))
+    elif type(num) is float:
+        num = np.sign(stop-start) * np.abs(num)
+        moves = list(np.arange(start, stop, num))
+        if np.isclose(moves[-1] + num, stop):
+            moves.append(moves[-1] + num)
+
+    return moves


### PR DESCRIPTION
## Description
Adds a decorator that modifies the arguments of the 1D scan plans to interpret floats as step size and integers as the number of steps.

## Motivation and Context
[Jira ticket](https://jira.slac.stanford.edu/browse/LCLSECSD-733)

I assumed that:
- `scan(-1, 1, 1.0)` should scan [-1, 0, 1], (end point included)
- `scan(0, 1, 0.3)` should scan [0, 0.3, 0.6, 0.9] (not including end point)

## How Has This Been Tested?
Interactively, some test cases added.  

## Where Has This Been Documented?
Docstrings

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
