### PR TITLE
WIP/ENH: Plan validation framework, extra checks

### DIFF
--- a/docs/source/upcoming_release_notes/56-step_size_decorator.rst
+++ b/docs/source/upcoming_release_notes/56-step_size_decorator.rst
@@ -1,0 +1,22 @@
+56 step size decorator
+#################
+
+API Changes
+-----------
+- 1-Dimensional scans now accept floats in the 'num' argument position and interprets it as a step size.
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -454,6 +454,7 @@ def daq_list_scan(*args, per_step=None, md=None):
 
 @bpp.reset_positions_decorator()
 @nbpp.daq_step_scan_decorator
+@nbpp.step_size_decorator
 def daq_ascan(detectors, motor, start, end, nsteps):
     """
     One-dimensional daq scan with absolute positions.
@@ -507,6 +508,7 @@ def daq_ascan(detectors, motor, start, end, nsteps):
 @bpp.reset_positions_decorator()
 @bpp.relative_set_decorator()
 @nbpp.daq_step_scan_decorator
+@nbpp.step_size_decorator
 def daq_dscan(detectors, motor, start, end, nsteps):
     """
     One-dimensional daq scan with relative (delta) positions.

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -455,7 +455,7 @@ def daq_list_scan(*args, per_step=None, md=None):
 @bpp.reset_positions_decorator()
 @nbpp.daq_step_scan_decorator
 @nbpp.step_size_decorator
-def daq_ascan(detectors, motor, start, end, nsteps):
+def daq_ascan(detectors, motor, start, end, n):
     """
     One-dimensional daq scan with absolute positions.
 
@@ -477,8 +477,9 @@ def daq_ascan(detectors, motor, start, end, nsteps):
     end : int or float
         The last point in the scan.
 
-    nsteps : int
-        The number of points in the scan.
+    n : int or float
+        if int, the number of points in the scan.
+        if float, step size
 
     events : int, optional
         Number of events to take at each step. If omitted, uses the
@@ -502,14 +503,14 @@ def daq_ascan(detectors, motor, start, end, nsteps):
     :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
     """
 
-    yield from bp.scan(detectors, motor, start, end, nsteps)
+    yield from bp.scan(detectors, motor, start, end, n)
 
 
 @bpp.reset_positions_decorator()
 @bpp.relative_set_decorator()
 @nbpp.daq_step_scan_decorator
 @nbpp.step_size_decorator
-def daq_dscan(detectors, motor, start, end, nsteps):
+def daq_dscan(detectors, motor, start, end, n):
     """
     One-dimensional daq scan with relative (delta) positions.
 
@@ -531,8 +532,9 @@ def daq_dscan(detectors, motor, start, end, nsteps):
     end : int or float
         The last point in the scan, relative to the current position.
 
-    nsteps : int
-        The number of points in the scan.
+    n : int or float
+        if int, the number of points in the scan.
+        if float, step size
 
     events : int, optional
         Number of events to take at each step. If omitted, uses the
@@ -556,7 +558,7 @@ def daq_dscan(detectors, motor, start, end, nsteps):
     :py:func:`nabs.preprocessors.daq_step_scan_decorator`.
     """
 
-    yield from bp.scan(detectors, motor, start, end, nsteps)
+    yield from bp.scan(detectors, motor, start, end, n)
 
 
 @bpp.reset_positions_decorator()

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -345,6 +345,8 @@ def step_size_decorator(plan):
         elif type(n) is float:
             # interpret as step size
             start, stop = args[2], args[3]
+            # correct step size sign
+            n = np.sign(stop - start) * np.abs(n)
             if np.abs(n) > np.abs(stop-start):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -341,23 +341,19 @@ def step_size_decorator(plan):
 
         if type(n) is int:
             # interpret as number of steps (default)
-            yield from plan(*args[:4], n, **kwargs)
-
+            yield from plan(*args, **kwargs)
         elif type(n) is float:
             # interpret as step size
             mmin, mmax = args[2], args[3]
-
             if n > (mmax-mmin):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "
                                  f"{mmax-mmin}")
-
             step_list = list(np.arange(mmin, mmax, n))
             # new endpoint needed, for cases where
             # (range % step_size) != 0 or to include endpoint
             if np.isclose(step_list[-1] + n, mmax):
                 step_list.append(step_list[-1] + n)
-
             n_steps = len(step_list)
 
             yield from plan(*args[:3], step_list[-1], n_steps,

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -332,10 +332,10 @@ def step_size_decorator(plan):
             # do not support num kwarg
             n = kwargs.pop('num')
         else:
-            # assumes (det_list, motor, mmin, mmax, num)
+            # assumes (det_list, motor, start, stop, num)
             n = args[-1]
 
-        if type(n) not in [int, float]:
+        if not isinstance(n, (int, float)):
             raise TypeError("Step size / number of steps is "
                             "neither float nor integer")
 
@@ -344,15 +344,19 @@ def step_size_decorator(plan):
             yield from plan(*args, **kwargs)
         elif type(n) is float:
             # interpret as step size
-            mmin, mmax = args[2], args[3]
-            if n > (mmax-mmin):
+            start, stop = args[2], args[3]
+            if np.abs(n) > np.abs(stop-start):
                 raise ValueError(f"Step size provided {n} greater "
                                  "than the range provided "
-                                 f"{mmax-mmin}")
-            step_list = list(np.arange(mmin, mmax, n))
+                                 f"{np.abs(stop-start)}")
+            step_list = list(np.arange(start, stop, n))
+            if len(step_list) == 0:
+                raise ValueError("Number of steps is 0 with the "
+                                 "provided range and step size.")
+
             # new endpoint needed, for cases where
             # (range % step_size) != 0 or to include endpoint
-            if np.isclose(step_list[-1] + n, mmax):
+            if np.isclose(step_list[-1] + n, stop):
                 step_list.append(step_list[-1] + n)
             n_steps = len(step_list)
 

--- a/nabs/simulators.py
+++ b/nabs/simulators.py
@@ -1,0 +1,172 @@
+"""Simulation and validation functions for plans"""
+import logging
+import pprint
+import sys  # NOQA
+from contextlib import contextmanager
+
+from bluesky.simulators import check_limits
+
+logger = logging.getLogger(__name__)
+
+
+class ValidError(Exception):
+    pass
+
+
+def check_open_close(plan):
+    """
+    Check if a plan is open and closed correctly.
+
+    Nested plans are allowed if they are labeled properly
+    with run tags.
+
+    Raises if a violation is found
+    If a message has as run key, all messages in that run must also.
+
+    Parameters
+    ----------
+    plan : iterable
+        Must yield `Msg` objects
+
+    Raises
+    ------
+    ValidError
+        If plan is not constructed correctly
+    """
+    stack = []
+    run_keys = []
+
+    for msg in plan:
+        if msg.command == 'open_run':
+            if msg.run in run_keys:
+                raise ValidError("Duplicate run_key found, plans "
+                                 "are nested incorrectly.")
+            stack.append(msg)
+            run_keys.append(msg.run)
+
+        elif msg.command == 'close_run':
+            _ = stack.pop()
+            key = run_keys.pop()
+            if key != msg.run:
+                raise ValidError("Mismatched run keys, open_run "
+                                 "and close_run misconfigured.")
+
+        else:
+            # generic message
+            if len(stack) == 0:
+                raise ValidError("Message found after all runs "
+                                 "have closed.")
+
+            if msg.run != stack[-1].run:
+                raise ValidError("Message does not match run key "
+                                 "of corresponding open_run. Plans "
+                                 "are probably nested incorrectly.")
+
+            if msg.run in run_keys[:-1]:
+                raise ValidError("Message run key does not match "
+                                 "that of nearest open_run.")
+
+
+def raiser(*args, **kwargs):
+    raise ValidError('forbidden method called')
+
+
+@contextmanager
+def patch_sys_modules(modules):
+    """
+    takes a list of module names as strings and stores them,
+    replaces them with a raiser, and replaces them after
+
+    Need to use exec/eval here due to pass-by-reference issues
+    """
+    cache = {}
+    for name in modules:
+        try:
+            cache[name] = eval(name)
+            exec(f'{name} = raiser')
+        except Exception as ex:
+            logger.debug(f'Failed to replace module {name}, {ex}')
+
+    yield
+
+    # replace the references
+    for name in cache:
+        exec(f'{name} = cache[name]')
+
+
+def check_stray_calls(plan):
+    """
+    Validate that plan does not invoke any caput functionality
+    outside of messages.
+
+    This is rather jank currently, it's entirely possible there is a
+    better way around this.
+
+    Relies on the pre-existing knowledge of which methods make calls
+    to pyepics/caput functionality.  These are:
+    - `ophyd.positioner.PositionerBase.move()`
+    - `pcdsdevices.interface.MvInterface.move()`
+    - ...
+
+    Parameters
+    ----------
+    plan : iterable
+        Must yield `Msg` objects
+
+    Raises
+    ------
+    ValidError
+        If attempts to access any forbidden methods
+    """
+
+    # context manager to replace sys.modules functions and replace
+    with patch_sys_modules(patches):
+        for _ in plan:
+            continue
+
+
+# be wary of how you specify these, they are keyed based on
+# how they were imported.
+patches = [
+            "sys.modules['ophyd.sim'].SynAxis.set",
+            "sys.modules['pcdsdevices'].interface.MvInterface.move"
+]
+
+
+validators = [
+    check_stray_calls,
+    check_limits,
+    check_open_close,
+]
+
+
+def validate_plan(plan, validators=validators):
+    """
+    Validate plan with all available checkers.
+
+    Parameters
+    ----------
+    plan: generator function
+        Once called, must yield `Msg` objects.
+
+    Returns
+    -------
+    boolean
+        Indicates if validation was successful (``True``) or failed
+        (``False``).
+    str
+        Error message that explains the reason for validation
+        failure. Empty string if validation is successful.
+
+    """
+    success, msg = True, ""
+    try:
+        for check in validators:
+            print(f'running {check.__name__}')
+            check(plan())
+    except Exception as ex:
+        print(ex)
+        msg = (f'Plan validation failed: {str(ex)}, for '
+               f'plan: {pprint.pformat(plan)}')
+        success = False
+    return success, msg

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -10,6 +10,7 @@ from pcdsdevices.pseudopos import DelayBase
 from pcdsdevices.sim import FastMotor
 
 import nabs.plans as nbp
+from nabs.utils import orange
 
 PLAN_TIMEOUT = 60
 logger = logging.getLogger(__name__)
@@ -388,19 +389,6 @@ def test_daq_fixed_target_multi_scan(RE, daq, hw, sample_file):
     assert len(reads) == 24
     RE(msgs)
     summarize_plan(msgs)
-
-
-def orange(start, stop, num):
-    """ get scan points """
-    if type(num) is int:
-        ex_moves = list(np.linspace(start, stop, num))
-    elif type(num) is float:
-        num = np.sign(stop-start) * np.abs(num)
-        ex_moves = list(np.arange(start, stop, num))
-        if np.isclose(ex_moves[-1] + num, stop):
-            ex_moves.append(ex_moves[-1] + num)
-
-    return ex_moves
 
 
 @pytest.mark.timeout(PLAN_TIMEOUT)

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -395,6 +395,7 @@ def orange(start, stop, num):
     if type(num) is int:
         ex_moves = list(np.linspace(start, stop, num))
     elif type(num) is float:
+        num = np.sign(stop-start) * np.abs(num)
         ex_moves = list(np.arange(start, stop, num))
         if np.isclose(ex_moves[-1] + num, stop):
             ex_moves.append(ex_moves[-1] + num)
@@ -410,6 +411,7 @@ def orange(start, stop, num):
      (-5, 5, 2., 18),    # step size, include endpoint
      (-1, 1, 0.3, 21),   # step size, end point not close
      (1, -1, -0.4, 18),  # positive to negative direction
+     (1, -1, 0.4, 18),   # ignore sign of step size
     ]
 )
 def test_daq_step_size(daq, hw, start, stop, num, n_reads):
@@ -452,7 +454,3 @@ def test_bad_step_size(RE, hw):
     with pytest.raises(ValueError):
         # step size bigger than range
         RE(nbp.daq_ascan([hw.det], hw.motor1, 0, 1, 20., events=1))
-
-    with pytest.raises(ValueError):
-        # bad step direction
-        RE(nbp.daq_ascan([hw.det], hw.motor1, 0, 1, -.4, events=1))

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -390,11 +390,23 @@ def test_daq_fixed_target_multi_scan(RE, daq, hw, sample_file):
     summarize_plan(msgs)
 
 
+def orange(mmin, mmax, num):
+    """ get scan points """
+    if type(num) is int:
+        ex_moves = list(np.linspace(mmin, mmax, num))
+    elif type(num) is float:
+        ex_moves = list(np.arange(mmin, mmax, num))
+        if np.isclose(ex_moves[-1] + num, mmax):
+            ex_moves.append(ex_moves[-1] + num)
+
+    return ex_moves
+
+
 @pytest.mark.timeout(PLAN_TIMEOUT)
 @pytest.mark.parametrize(
     'mmin, mmax, num, n_reads',
     [
-     (-5, 5, 11, 33),
+     (-5, 5, 11, 33),   # expect 3 reads / point (det, motor, daq)
      (-5, 5, 2., 18),   # step size, include endpoint
      (-1, 1, 0.3, 21),  # step size, end point not close
     ]
@@ -405,15 +417,11 @@ def test_daq_step_size(daq, hw, mmin, mmax, num, n_reads):
     hw.motor1.set(x_start)
     msgs = list(nbp.daq_ascan([hw.det], hw.motor1,
                               mmin, mmax, num, events=1))
-    if type(num) is int:
-        a_expected_moves = list(np.linspace(mmin, mmax, num))
-    elif type(num) is float:
-        a_expected_moves = list(np.arange(mmin, mmax, num))
-        if np.isclose(a_expected_moves[-1] + num, mmax):
-            a_expected_moves.append(a_expected_moves[-1] + num)
 
     a_moves = [msg.args[0] for msg in msgs if msg.command == 'set']
     reads = [msg for msg in msgs if msg.command == 'read']
+
+    a_expected_moves = orange(mmin, mmax, num)
 
     assert np.isclose(a_moves, a_expected_moves + [x_start]).all()
     assert len(reads) == n_reads
@@ -422,14 +430,10 @@ def test_daq_step_size(daq, hw, mmin, mmax, num, n_reads):
     hw.motor1.set(x_start)
     msgs = list(nbp.daq_dscan([hw.det], hw.motor1,
                               mmin, mmax, num, events=1))
-    if type(num) is int:
-        d_expected_moves = list(np.linspace(mmin + x_start,
-                                            mmax + x_start, num))
-    elif type(num) is float:
-        d_expected_moves = list(np.arange(mmin + x_start,
-                                          mmax + x_start, num))
-        if np.isclose(d_expected_moves[-1] + num, mmax + x_start):
-            d_expected_moves.append(d_expected_moves[-1] + num)
+
+    d_min = mmin + x_start
+    d_max = mmax + x_start
+    d_expected_moves = orange(d_min, d_max, num)
 
     d_moves = [msg.args[0] for msg in msgs if msg.command == 'set']
     reads = [msg for msg in msgs if msg.command == 'read']

--- a/nabs/tests/test_simulators.py
+++ b/nabs/tests/test_simulators.py
@@ -1,0 +1,87 @@
+import bluesky.plan_stubs as bps
+import bluesky.plans as bp
+import bluesky.preprocessors as bpp
+import numpy as np
+import pytest
+from ophyd.sim import SynAxis, hw
+
+from nabs.simulators import validate_plan
+
+hw = hw()
+
+
+class LimitedMotor(SynAxis):
+    def check_value(self, value, **kwargs):
+        if np.abs(value) > 10:
+            raise ValueError("value out of bounds")
+
+
+limit_motor = LimitedMotor(name='limit_motor', labels={'motors'})
+
+
+@bpp.set_run_key_decorator("run_2")
+@bpp.run_decorator(md={})
+def sim_plan_inner(npts=2):
+    for j in range(npts):
+        yield from bps.mov(hw.motor1, j * 0.1 + 1,
+                           hw.motor2, j * 0.2 - 2)
+        yield from bps.trigger_and_read([hw.motor1, hw.motor2,
+                                         hw.det2])
+
+
+@bpp.set_run_key_decorator("run_1")
+@bpp.run_decorator(md={})
+def sim_plan_outer(npts=4):
+    for j in range(int(npts/2)):
+        yield from bps.mov(hw.motor, j * 0.2)
+        yield from bps.trigger_and_read([hw.motor, hw.det])
+
+    yield from sim_plan_inner(npts + 1)
+
+    for j in range(int(npts/2), npts):
+        yield from bps.mov(hw.motor, j * 0.2)
+        yield from bps.trigger_and_read([hw.motor, hw.det])
+
+
+def bad_limits():
+    yield from bps.open_run()
+    yield from bps.sleep(1)
+    yield from bps.mv(limit_motor, 100)
+    yield from bps.sleep(1)
+    yield from bps.close_run()
+
+
+def bad_nesting():
+    yield from bps.open_run()
+    yield from bp.count([])
+    yield from bps.close_run()
+
+
+def bad_call():
+    yield from bps.open_run()
+    limit_motor.set(10)
+    yield from bps.close_run()
+
+
+@pytest.mark.parametrize(
+    'plan',
+    [
+     bad_limits,
+     bad_nesting,
+     bad_call,
+    ]
+)
+def test_bad_plans(plan):
+    success, _ = validate_plan(plan)
+    assert success is False
+
+
+@pytest.mark.parametrize(
+    'plan',
+    [
+     sim_plan_outer,
+    ]
+)
+def test_good_plans(plan):
+    success, _ = validate_plan(plan)
+    assert success is True

--- a/nabs/utils.py
+++ b/nabs/utils.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Any, Callable, Dict, Union
 
+import numpy as np
 from ophyd.signal import DerivedSignal, SignalRO
 
 
@@ -110,3 +111,39 @@ def add_named_kwargs_to_signature(
     )
 
     return sig.replace(parameters=start_params + wrapper_params + end_params)
+
+
+def orange(start, stop, num):
+    """
+    Get scan points based on the type of `num`.  If `num` is an
+    integer, interpret as the number of points in a scan.  If `num`
+    is a float, interpret it as a step size.
+
+    Modified to include end points.
+
+    Parameters
+    ----------
+    start : int or float
+        The first point in the scan
+
+    end : int or float
+        The last point in the scan
+
+    n : int or float
+        if int, the number of points in the scan.
+        if float, step size
+
+    Returns
+    -------
+    list
+        a list of scan points
+    """
+    if type(num) is int:
+        moves = list(np.linspace(start, stop, num))
+    elif type(num) is float:
+        num = np.sign(stop-start) * np.abs(num)
+        moves = list(np.arange(start, stop, num))
+        if np.isclose(moves[-1] + num, stop):
+            moves.append(moves[-1] + num)
+
+    return moves


### PR DESCRIPTION
## Description
Adds a high level `validate_plan` function that runs a plan through multiple checks.  
Adds check for proper plan construction (open_run/close_run matching, proper `run_key` tags)
Adds check for stray calls, pulling from a pre-defined list of forbidden function calls.

## Motivation and Context
Plan verification has always been on our radar, but hasn't been fully fleshed out.  One could see this being useful to scientists building their own plans as a quick check before running them on the beamline.  With the more recently developed RunWrapper functionality, one could see these checks being run before a plan is added to the hutch-python namespace and made available for generic use.

All of these plans attempt to simply examine messages, and as such avoid actually taking any actions. This does not, however, prevent a user from directly moving a motor within a plan via `.put()` or similar methods.

`check_stray_calls` attempts to remedy this by temporarily monkeypatching `sys.modules`.  This may not be the best way to go about it, but it seemed more viable than:
- simple code inspection via AST's, which would not be able to catch calls nested inside helper functions
- static code analysis, which might be a little too heavy

## How Has This Been Tested?
Test suite has been started.  
interactively, for non-simulated motors

Still needs further testing with live PV's, and additional "forbidden methods"

## Where Has This Been Documented?
Some docstrings, but mostly this PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
