### PR TITLE
ENH: Read metadata to configure BEC, disable plots for delay_scan

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,9 +22,10 @@ requirements:
       - numpy
       - ophyd
       - pandas
-      - pyqt <5.15.0
       - scipy
       - toolz
+    run_constrained:
+      - pyqt <5.15.0
 
 test:
     imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
       - numpy
       - ophyd
       - pandas
+      - pyqt <5.15.0
       - scipy
       - toolz
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 flake8
 matplotlib
 pytest
-pyqt5<5.15.0
 pcdsdaq
 pcdsdevices

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 flake8
 matplotlib
 pytest
+pyqt <5.15.0
 pcdsdaq
 pcdsdevices

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 matplotlib
 pytest
-pyqt <5.15.0
+pyqt5<5.15.0
 pcdsdaq
 pcdsdevices

--- a/docs/source/upcoming_release_notes/61-BEC_reads_metadata.rst
+++ b/docs/source/upcoming_release_notes/61-BEC_reads_metadata.rst
@@ -1,0 +1,23 @@
+61 BEC_reads_metadata
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Wraps the BEC in a callback that looks for run metadata and modifies
+  functionality accordingly.
+
+Bugfixes
+--------
+- Disables plotting for delay_scan
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -221,7 +221,7 @@ class BECOptionsPerRun(BestEffortCallback):
         super().stop(doc)
 
     def restore_settings(self):
-        # reset bec settings if they exist
+        """Reset bec settings if they exist."""
         if self.prev_settings:
             for k, v in self.prev_settings.items():
                 setattr(self, k, v)

--- a/nabs/callbacks.py
+++ b/nabs/callbacks.py
@@ -194,8 +194,7 @@ class BECOptionsPerRun(BestEffortCallback):
         super().__init__(*args, **kwargs)
 
     def start(self, doc):
-        # clear history
-        self.prev_settings = {}
+        self.restore_settings()
 
         # store bec settings
         for k, v in self.valid_keys.items():
@@ -218,8 +217,14 @@ class BECOptionsPerRun(BestEffortCallback):
         super().start(doc)
 
     def stop(self, doc):
-        # reset bec settings
-        for k, v in self.prev_settings.items():
-            setattr(self, k, v)
-
+        self.restore_settings()
         super().stop(doc)
+
+    def restore_settings(self):
+        # reset bec settings if they exist
+        if self.prev_settings:
+            for k, v in self.prev_settings.items():
+                setattr(self, k, v)
+
+        # clear previous settings
+        self.prev_settings = {}

--- a/nabs/plans.py
+++ b/nabs/plans.py
@@ -118,6 +118,7 @@ def duration_scan(detectors, *args, duration=0, per_step=None, md=None):
 
     _md['hints'] = default_hints
     _md['hints'].update(md.get('hints', {}) or {})
+    _md['disable_plots'] = True
     # end borrowed md handling block
 
     @bpp.stage_decorator(detectors + motors)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ bluesky>=1.6.5
 numpy
 ophyd
 pandas
+pyqt5<5.15.0
 scipy
 toolz


### PR DESCRIPTION
## Description
- adds BECOptionPerRun, which wraps the BEC and looks for run metadata to disable or enable functionality.
- uses the above feature to disable plots for duration_scan, and by extension delay_scan

## Motivation and Context
[Jira](https://jira.slac.stanford.edu/browse/LCLSECSD-1090)

Added to hutch-python in pcdshub/hutch-python#340 

Certain scans give BestEffortCallback some difficulty, and we want a way to turn off plots on a per-run basis.  There aren't any natural (read: easy) ways to do this, so we have to modify the callback a bit to look for metadata tags.  

~~"Normally" one would simply pass a factory function to the RunRouter, but in our case we want to only modify the BEC for a single run.  To reset the BEC, we must remember a bit about its state, leading to this strange FactoryFaker thing.~~

This was done by simply subclassing BEC in a wrapper callback that keeps track of state and reacts to run metadata.

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
Some docstrings, this PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
