### PR TITLE
FIX: daq wrapper duration arg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.6 - PIP"
-    - name: "Python 3.7"
-    - name: "Python 3.8"
+    - name: "Python - PIP"
 
 import:
   # This import enables a set of standard python jobs including:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ env:
     # CONDA_EXTRAS) but for pip
     - PIP_EXTRAS=""
 
-jobs:
-  allow_failures:
-    - name: "Python - PIP"
+# jobs:
+#   allow_failures:
+#     - name: "Python - PIP"
 
 import:
   # This import enables a set of standard python jobs including:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 flake8
 matplotlib
 pytest
+pytest-timeout
 pcdsdaq
 pcdsdevices

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 flake8
 matplotlib
 pytest
-pytest-coverage
 pytest-timeout
 pcdsdaq
 pcdsdevices

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 flake8
 matplotlib
 pytest
+pytest-coverage
 pytest-timeout
 pcdsdaq
 pcdsdevices

--- a/docs/source/upcoming_release_notes/64-daq_duration_arg.rst
+++ b/docs/source/upcoming_release_notes/64-daq_duration_arg.rst
@@ -17,6 +17,8 @@ Bugfixes
 Maintenance
 -----------
 - Make the test suite pass on Windows
+- Make the test suite compatible with bluesky v1.9.0
+- Make the test suite compatible with python 3.8
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/64-daq_duration_arg.rst
+++ b/docs/source/upcoming_release_notes/64-daq_duration_arg.rst
@@ -1,0 +1,23 @@
+64 daq_duration_arg
+###################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where any of the daq step scans would fail if run with the
+  ``duration`` arg instead of the ``events`` arg.
+
+Maintenance
+-----------
+- Make the test suite pass on Windows
+
+Contributors
+------------
+- zllentz

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -112,9 +112,29 @@ def daq_step_scan_wrapper(plan, events=None, duration=None, record=True,
         daq_has_triggered = False
 
     def daq_first_cycle(msg):
-        yield from bps.configure(daq, events=events, duration=duration,
-                                 record=record, use_l3t=use_l3t,
-                                 controls=list(motor_cache))
+        if events is not None:
+            yield from bps.configure(
+                daq,
+                events=events,
+                record=record,
+                use_l3t=use_l3t,
+                controls=list(motor_cache),
+            )
+        elif duration is not None:
+            yield from bps.configure(
+                daq,
+                duration=duration,
+                record=record,
+                use_l3t=use_l3t,
+                controls=list(motor_cache),
+            )
+        else:
+            yield from bps.configure(
+                daq,
+                record=record,
+                use_l3t=use_l3t,
+                controls=list(motor_cache),
+            )
         return (yield from add_daq_trigger(msg))
 
     def add_daq_trigger(msg):

--- a/nabs/simulators.py
+++ b/nabs/simulators.py
@@ -1,6 +1,7 @@
 """Simulation and validation functions for plans"""
 import itertools
 import logging
+import sys
 from contextlib import contextmanager
 from typing import Any, Generator, Iterator, List, Tuple
 
@@ -139,6 +140,8 @@ def check_stray_calls(
     Relies on the pre-existing knowledge of which methods make calls
     to pyepics/caput functionality.
 
+    This does not work on Windows.
+
     Parameters
     ----------
     plan : iterable or generator
@@ -164,12 +167,20 @@ def check_stray_calls(
     p.join_and_raise()
 
 
-# check_limits is not hinted, so hinting this becomes miserable
-validators = [
-    check_stray_calls,
-    check_open_close,
-    check_limits,
-]
+if sys.platform == 'win32':
+    # check_stray_calls does not work on windows due to differences in
+    # the implementation of multiprocessing
+    validators = [
+        check_open_close,
+        check_limits,
+    ]
+else:
+    # check_limits is not hinted, so hinting this becomes miserable
+    validators = [
+        check_stray_calls,
+        check_open_close,
+        check_limits,
+    ]
 
 
 def validate_plan(

--- a/nabs/tests/conftest.py
+++ b/nabs/tests/conftest.py
@@ -1,9 +1,8 @@
-import asyncio
 import os
 import sys
 
 import pytest
-from bluesky import RunEngine
+from bluesky.run_engine import RunEngine, get_bluesky_event_loop
 from ophyd.device import Component as Cpt
 from ophyd.positioner import SoftPositioner
 from ophyd.pseudopos import (PseudoPositioner, PseudoSingle,
@@ -15,9 +14,9 @@ from pcdsdaq.sim import set_sim_mode
 
 @pytest.fixture(scope='function')
 def RE():
-    loop = asyncio.new_event_loop()
+    RE = RunEngine({})
+    loop = get_bluesky_event_loop()
     loop.set_debug(True)
-    RE = RunEngine({}, loop=loop)
 
     yield RE
 

--- a/nabs/tests/conftest.py
+++ b/nabs/tests/conftest.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import sys
 
 import pytest
 from bluesky import RunEngine
@@ -141,3 +143,8 @@ test_sample:
     status: false
     """)
     return sample_file
+
+
+@pytest.fixture(scope='function', autouse=(sys.platform == 'win32'))
+def patch_uname_for_windows(monkeypatch):
+    monkeypatch.setattr(os, 'uname', lambda: 'hostname', raising=False)

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from collections import defaultdict
 
 import numpy as np
@@ -6,11 +7,20 @@ import pytest
 from bluesky.simulators import summarize_plan
 from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
-from pcdsdevices.pseudopos import DelayBase
-from pcdsdevices.sim import FastMotor
 
 import nabs.plans as nbp
 from nabs.utils import orange
+
+# pcdsdevices no longer imports properly on python 3.8
+if sys.version_info >= (3, 9):
+    from pcdsdevices.pseudopos import DelayBase
+    from pcdsdevices.sim import FastMotor
+    run_time_motor_tests = True
+else:
+    DelayBase = object
+    FastMotor = object
+    run_time_motor_tests = False
+
 
 PLAN_TIMEOUT = 60
 logger = logging.getLogger(__name__)
@@ -51,6 +61,8 @@ class SimDelayStage(DelayBase):
 
 @pytest.fixture(scope='function')
 def time_motor():
+    if not run_time_motor_tests:
+        pytest.skip(reason='pcdsdevices tests do not run prior to python 3.9')
     return SimDelayStage('SIM', name='sim', egu='s', n_bounces=1)
 
 

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -397,7 +397,7 @@ def test_daq_fixed_target_multi_scan(RE, daq, hw, sample_file):
     [
      (-5, 5, 11, 33),    # expect 3 reads / point (det, motor, daq)
      (-5, 5, float(1.), 33),    # step size, include endpoint
-     (-1, 1, np.float128(0.2), 33),   # step size, end point not close
+     (-1, 1, np.float64(0.2), 33),   # step size, end point not close
      (1, -1, -0.4, 18),  # positive to negative direction
      (1, -1, np.float64(0.4), 18),   # ignore step sign
      (-1, 0, np.float32(0.1), 33),  # close to 0, end near start

--- a/nabs/tests/test_preprocessors.py
+++ b/nabs/tests/test_preprocessors.py
@@ -81,11 +81,19 @@ def test_daq_step_scan_args(hw, daq, daq_step_scan):
     assert_no_lost_msg(nodaq_none_det, nodaq_none_det)
 
 
-def test_daq_step_scan_run(RE, hw, daq_step_scan):
+def test_daq_step_scan_run_events(RE, hw, daq_step_scan):
     """
     Actually run a scan and make sure it doesn't error out.
     """
     RE(daq_step_scan([hw.det], hw.motor, 0, 10, 11, events=10, record=False,
+                     use_l3t=True))
+
+
+def test_daq_step_scan_run_duration(RE, hw, daq_step_scan):
+    """
+    Actually run a scan and make sure it doesn't error out.
+    """
+    RE(daq_step_scan([hw.det], hw.motor, 0, 10, 11, duration=1, record=False,
                      use_l3t=True))
 
 

--- a/nabs/tests/test_preprocessors.py
+++ b/nabs/tests/test_preprocessors.py
@@ -91,9 +91,18 @@ def test_daq_step_scan_run_events(RE, hw, daq_step_scan):
 
 def test_daq_step_scan_run_duration(RE, hw, daq_step_scan):
     """
-    Actually run a scan and make sure it doesn't error out.
+    Again, but with duration arg instead of events arg
     """
-    RE(daq_step_scan([hw.det], hw.motor, 0, 10, 11, duration=1, record=False,
+    RE(daq_step_scan([hw.det], hw.motor, 0, 10, 2, duration=1, record=False,
+                     use_l3t=True))
+
+
+def test_daq_step_scan_preconfigured(RE, hw, daq, daq_step_scan):
+    """
+    Again, but the user passes neither! (configured first)
+    """
+    daq.configure(events=10)
+    RE(daq_step_scan([hw.det], hw.motor, 0, 10, 11, record=False,
                      use_l3t=True))
 
 

--- a/nabs/tests/test_simulators.py
+++ b/nabs/tests/test_simulators.py
@@ -1,3 +1,5 @@
+import sys
+
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import bluesky.preprocessors as bpp
@@ -71,13 +73,15 @@ def bad_stage():
 @pytest.mark.parametrize(
     'plan',
     [
-     bad_limits(),
-     bad_nesting(),
-     bad_call(),
+     bad_limits,
+     bad_nesting,
+     bad_call,
     ]
 )
 def test_bad_plans(plan):
-    success, _ = validate_plan(plan)
+    if sys.platform == 'win32' and plan is bad_call:
+        pytest.skip(reason='bad_call check does not work on windows')
+    success, _ = validate_plan(plan())
     assert not success, "Plan was supposed to be bad"
 
 

--- a/nabs/tests/test_simulators.py
+++ b/nabs/tests/test_simulators.py
@@ -78,7 +78,7 @@ def bad_stage():
      bad_call,
     ]
 )
-def test_bad_plans(plan):
+def test_bad_plans(RE, plan):
     if sys.platform == 'win32' and plan is bad_call:
         pytest.skip(reason='bad_call check does not work on windows')
     success, _ = validate_plan(plan())
@@ -95,6 +95,6 @@ def test_bad_plans(plan):
      nbp.daq_dscan([hw.det], hw.motor, 1, 0, 2, events=1)
     ]
 )
-def test_good_plans(plan, daq):
+def test_good_plans(RE, plan, daq):
     success, msg = validate_plan(plan)
     assert success, msg

--- a/nabs/tests/test_simulators.py
+++ b/nabs/tests/test_simulators.py
@@ -78,7 +78,7 @@ def bad_stage():
 )
 def test_bad_plans(plan):
     success, _ = validate_plan(plan)
-    assert success is False
+    assert not success, "Plan was supposed to be bad"
 
 
 @pytest.mark.parametrize(
@@ -92,5 +92,5 @@ def test_bad_plans(plan):
     ]
 )
 def test_good_plans(plan, daq):
-    success, _ = validate_plan(plan)
-    assert success is True
+    success, msg = validate_plan(plan)
+    assert success, msg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix an issue where any of the DAQ step scans would fail if a `duration` arg was passed instead of an `events` arg.
- Make the test suite run on windows for my offline testing.
- Make some of the tests display a better error message to help me track down why they were failing on windows.
- Make the test suite compatible with bluesky v1.9.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- @vespos pointed this out 2 weeks ago where the scans did not behave as intended. They would error out if we used the `duration` arg. This is used less often so it has gone unnoticed.
- Offline testing is convenient for me.
- closes #64 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added tests. The test that I added prior to the fix commit fails without the fix. With the fix, the test passes.
I have not run the tests again on linux, hopefully travis can help me here.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
The bugfix will be included in the release notes.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
