### PR TITLE
MAINT: scripted fix for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.8.4
     hooks:
     -   id: flake8

--- a/docs/source/upcoming_release_notes/67-maint_auto_fix_precommit.rst
+++ b/docs/source/upcoming_release_notes/67-maint_auto_fix_precommit.rst
@@ -1,0 +1,22 @@
+67 maint_auto_fix_precommit
+###########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Fix an issue with the pre-commit config pointing to a missing url mirror.
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
PR generated from script to fix .pre-commit-config.yaml in all repos, switching out the missing flake8 gitlab mirror for github.