### PR TITLE
BLD: ensure that the test environment never picks the broken version of pcdsdevices

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
   requires:
   - matplotlib-base
   - pcdsdaq
-  - pcdsdevices
+  - pcdsdevices >=7.2.0
   - pytest
   - pytest-timeout
   imports:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Force pcdsdevices>=7.2.0 in the conda tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the GHA python 3.9 CI, pcdsdevices 7.1.0 build 0 is being picked over build 2 and over all later versions, but this specific build is broken.
Let's see what the solver selects when we force something higher than this build.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on travis
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
