### PR TITLE
MNT/BLD: unpin pyqt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,6 @@
 - [ ] Code contains descriptive docstrings, including context and API
 - [ ] New/changed functions and methods are covered in the test suite where possible
 - [ ] Test suite passes locally
-- [ ] Test suite passes on travis
+- [ ] Test suite passes on GitHub Actions
 - [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
 - [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   - scipy
   - toolz
   run_constrained:
-  - pyqt <5.15.0
+  - pyqt =5
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.6
-  - bluesky >=1.6.5
+  - bluesky >=1.6.5,<1.11
   - numpy
   - ophyd
   - pandas

--- a/docs/source/upcoming_release_notes/74-free-pyqt.rst
+++ b/docs/source/upcoming_release_notes/74-free-pyqt.rst
@@ -1,0 +1,22 @@
+74 free-pyqt
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adjust PyQt pinning to select PyQt5.
+
+Contributors
+------------
+- klauer

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ bluesky>=1.6.5
 numpy
 ophyd
 pandas
-pyqt5<5.15.0
+pyqt5
 scipy
 toolz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bluesky>=1.6.5
+bluesky>=1.6.5,<1.11
 numpy
 ophyd
 pandas


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Unpin pyqt, leaving it at 5.x.

## Motivation and Context
We're looking forward to Python 3.11 everywhere.

`hutch-python > nabs` dependency means that hutch-python and these libraries currently require `pyqt < 5.15` in our environment. Those versions are not available for Python 3.11. PyDM and our other libraries are now (likely/mostly) compatible with PyQt 5.15, so releasing the pin here is our next step toward that transition.

## How Has This Been Tested?
Untested. Relying on CI, which is likely to fail due to bluesky-related changes.

## Where Has This Been Documented?
This PR text.

## Pre-merge checklist
- [ ] Test suite passes on travis
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
