### PR TITLE
ENH: raise an error if the daq has not yet been configured

### DIFF
--- a/docs/source/upcoming_release_notes/76-no-daq-raise.rst
+++ b/docs/source/upcoming_release_notes/76-no-daq-raise.rst
@@ -1,0 +1,23 @@
+76 no-daq-raise
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Raise an error if the daq has not yet been initialized in the hutch-python
+  session.
+
+Contributors
+------------
+- klauer

--- a/nabs/exceptions.py
+++ b/nabs/exceptions.py
@@ -1,0 +1,6 @@
+class NabsError(Exception):
+    """Base class for nabs-related errors."""
+
+
+class DaqNotConfiguredError(NabsError):
+    """The DAQ has not yet been configured."""

--- a/nabs/preprocessors.py
+++ b/nabs/preprocessors.py
@@ -17,6 +17,7 @@ import numpy as np
 from bluesky.utils import make_decorator
 
 from . import utils
+from .exceptions import DaqNotConfiguredError
 
 
 def _get_daq():
@@ -33,7 +34,12 @@ def _get_daq():
     """
 
     from pcdsdaq.daq import get_daq  # NOQA
-    return get_daq()
+    daq = get_daq()
+    if daq is None:
+        raise DaqNotConfiguredError(
+            "The daq must first be configured to be used in a scan."
+        )
+    return daq
 
 
 class _Dummy:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Raise an error if the daq object is not available/has not been instantiated/configured in the current session.

## Motivation and Context
@vespos reported that a simple daq scan raised the following error:

```
>>> RE(bp.daq_ascan([], sim.fast_motor1, 920, 930, 11, events=120, record=False))
...
AttributeError: 'NoneType' object has no attribute 'parent'
```

This indicates to me that `None` is making its way into the detector list in bluesky.
Getting a confusing error like this isn't very friendly, so let's catch it early.

## How Has This Been Tested?

## Where Has This Been Documented?
This PR text.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
