### PR TITLE
TST/BLD: unpin upper bluesky constraint

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.6
-  - bluesky >=1.6.5,<1.11
+  - bluesky >=1.6.5
   - numpy
   - ophyd
   - pandas

--- a/docs/source/upcoming_release_notes/79-bld_unpin_bluesky.rst
+++ b/docs/source/upcoming_release_notes/79-bld_unpin_bluesky.rst
@@ -1,0 +1,22 @@
+79 bld_unpin_bluesky
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Updates test suite and some plans for numpy 2.0 compatibility (primarily with updated bluesky >1.12.0)
+
+Contributors
+------------
+- tangkong

--- a/nabs/optimize.py
+++ b/nabs/optimize.py
@@ -107,8 +107,8 @@ def optimize(signal, motor, tolerance,
         signal = InvertedSignal(raw)
 
     # Create plan metadata
-    _md = {'detectors': [signal],
-           'motors': [motor],
+    _md = {'detectors': [signal.name],
+           'motors': [motor.name],
            'plan_args': {'signal': repr(signal),
                          'motor': repr(motor),
                          'tolerance': tolerance,

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -286,7 +286,7 @@ def test_fixed_target_scan(RE, hw, sample_file):
     assert moves == expected_moves
 
     RE(msgs)
-    summarize_plan(msgs)
+    summarize_plan(m for m in msgs)
 
     with pytest.raises(IndexError):
         RE(nbp.fixed_target_scan(sample='test_sample', detectors=[hw.det],
@@ -327,7 +327,7 @@ def test_fixed_target_multi_scan(RE, hw, sample_file):
     assert len(reads) == 24
 
     RE(msgs)
-    summarize_plan(msgs)
+    summarize_plan(m for m in msgs)
 
 
 @pytest.mark.timeout(PLAN_TIMEOUT)
@@ -351,7 +351,7 @@ def test_daq_fixed_target_scan(RE, daq, hw, sample_file):
     assert configure_message.kwargs['controls'] == [hw.motor1, hw.motor2,
                                                     hw.motor3]
     RE(msgs)
-    summarize_plan(msgs)
+    summarize_plan(m for m in msgs)
 
 
 @pytest.mark.timeout(PLAN_TIMEOUT)
@@ -396,7 +396,7 @@ def test_daq_fixed_target_multi_scan(RE, daq, hw, sample_file):
     assert moves == expected_moves
     assert len(reads) == 24
     RE(msgs)
-    summarize_plan(msgs)
+    summarize_plan(m for m in msgs)
 
 
 @pytest.mark.timeout(PLAN_TIMEOUT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bluesky>=1.6.5,<1.11
+bluesky>=1.6.5
 numpy
 ophyd
 pandas


### PR DESCRIPTION
## Description
Try releasing the upper pin on bluesky for future illumine compatibility

## Motivation and Context
Revisiting this now that numpy 2.0 turned our lives upside down

## How Has This Been Tested?
Go gha go

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
