### PR TITLE
CI: pin numpy in CI tests for downstream incompatibilities

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -17,9 +17,10 @@ jobs:
       package-name: "nabs"
       # Extras that will be installed for both conda/pip:
       testing-extras: ""
+      # Temporary numpy<2 while downstream packages slowly update
       # Extras to be installed only for conda-based testing:
-      conda-testing-extras: "pip"
+      conda-testing-extras: "pip numpy<2"
       # Extras to be installed only for pip-based testing:
-      pip-testing-extras: ""
+      pip-testing-extras: "numpy<2"
       # Set if using setuptools-scm for the conda-build workflow
       use-setuptools-scm: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Pin numpy back in CI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is one of the reasons why CI may not pass and I need to make an edit to make a PR and I want to see how close this is to being interoperable with bluesky latest. I saw some alpha builds on conda but no pypi builds yet of the upcoming bluesky tag.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
