### PR TITLE
BLD: try using pre-release bluesky for upstream compat

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.6
-  - bluesky-base >1.12.0
+  - bluesky-base =1.10.0
   - numpy <2.0.0
   - ophyd
   - pandas

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.6
-  - bluesky-base >=1.6.5
+  - bluesky-base >1.12.0
   - numpy <2.0.0
   - ophyd
   - pandas

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 flake8
 matplotlib
+pyqt5
 pytest
 pytest-timeout
 pcdsdaq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bluesky>=1.6.5
+bluesky>1.12.0
 numpy<2.0.0
 ophyd
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bluesky>1.12.0
+bluesky=1.10.0
 numpy<2.0.0
 ophyd
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bluesky=1.10.0
+bluesky==1.10.0
 numpy<2.0.0
 ophyd
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ bluesky==1.10.0
 numpy<2.0.0
 ophyd
 pandas
-pyqt5
 scipy
 toolz


### PR DESCRIPTION
## Description
I believe bluesky is now updated to >1.12.0 on pypi and conda-forge.  Let's see if it builds here

## Motivation and Context
I think we still skip nabs in our next tag.  I'm pondering adding it to conda-forge for completeness, and may do so anyway since it'll pick up the old nabs tag

## How Has This Been Tested?
CI gogogo

## Where Has This Been Documented?
This PR 

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
