### PR TITLE
BLD: unpin numpy, more upstream packages compatible

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
   - python >=3.6
   - bluesky-base =1.10.0
-  - numpy <2.0.0
+  - numpy
   - ophyd
   - pandas
   - scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bluesky==1.10.0
-numpy<2.0.0
+numpy
 ophyd
 pandas
 scipy


### PR DESCRIPTION
## Description
Unpin numpy, more upstream packages are compatible now

## Motivation and Context
I want newer environments

## How Has This Been Tested?
CI Hopefully

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
