### PR TITLE
DOC: update release notes for 1.5.6, not yet tagged

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -2,13 +2,12 @@ Release History
 ###############
 
 
-v1.5.6 (2024-08-20)
+v1.5.6 (2025-03-19)
 ===================
 
 Maintenance
 -----------
 - Updates test suite and some plans for numpy 2.0 compatibility (primarily with updated bluesky >1.12.0).
-  Note that the dependencies of nabs are still not numpy 2.0 compatible.
 - Specify bluesky-base in conda recipe to remove matplotlib qt dependencies
 
 Contributors


### PR DESCRIPTION
## Description
Apparently I made release notes a while back but never tagged the package.  Updating them to reflect the new acceptance of numpy 2.0

## Motivation and Context
new env 

## How Has This Been Tested?
CI one more time

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
