### PR TITLE
BLD: unpin bluesky, numpy2.0 supported now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -23,11 +23,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.6
-  - bluesky-base =1.10.0
+  - bluesky-base
   - numpy
   - ophyd
   - pandas

--- a/docs/source/upcoming_release_notes/86-bld_bluesky_unpin.rst
+++ b/docs/source/upcoming_release_notes/86-bld_bluesky_unpin.rst
@@ -1,0 +1,22 @@
+86 bld_bluesky_unpin
+####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- unpin bluesky, compatiblity achieved
+
+Contributors
+------------
+- tangkong

--- a/nabs/tests/test_plans.py
+++ b/nabs/tests/test_plans.py
@@ -69,7 +69,7 @@ def test_delay_scan(RE, hw, time_motor):
 
     # Speed of light is more or less 3e8
     goal = 1/(3e8)
-    msgs = nbp.delay_scan([hw.det], time_motor, [0, goal], 1, duration=0.01)
+    msgs = nbp.delay_scan([hw.det], time_motor, [0, goal], 1, duration=0.1)
     moves = list(msg.args[0] for msg in msgs if msg.command == 'set')
     # first point is the velo, which should be close to 1 with 1 bounce set
     assert np.isclose(moves[0], 1, rtol=1e-2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bluesky==1.10.0
+bluesky
 numpy
 ophyd
 pandas


### PR DESCRIPTION
## Description
Unpin bluesky, now that numpy is officially supported.

## Motivation and Context
I dream of numpy 2.0

## How Has This Been Tested?
CI here 

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
